### PR TITLE
feat: Marginal relief in surcharge

### DIFF
--- a/india_payroll/hooks.py
+++ b/india_payroll/hooks.py
@@ -261,6 +261,12 @@ doc_events = {
 # ]
 
 # Automatically update python controller files with type annotations for this app.
+regional_overrides = {
+	"India": {
+		"hrms.payroll.doctype.income_tax_slab.income_tax_slab.apply_surcharge_with_marginal_relief": "india_payroll.india_payroll.income_tax_utils.apply_surcharge_with_marginal_relief",
+	}
+}
+
 export_python_type_annotations = True
 
 # Require all whitelisted methods to have type annotations

--- a/india_payroll/india_payroll/income_tax_utils.py
+++ b/india_payroll/india_payroll/income_tax_utils.py
@@ -1,0 +1,54 @@
+from frappe.utils import flt
+from hrms.payroll.doctype.income_tax_slab.income_tax_slab import calculate_base_tax_from_tax_slabs
+
+
+def apply_surcharge_with_marginal_relief(
+	tax_amount, annual_taxable_earning, tax_slab, eval_globals, eval_locals
+):
+	"""
+	India regional override for apply_surcharge_with_marginal_relief.
+	Returns (tax_amount_with_surcharge, total_surcharge).
+	Surcharge rows are identified by descriptions starting with "Surcharge".
+	Only one surcharge tier fires per income level (non-overlapping min/max ranges).
+	"""
+	total_surcharge = 0.0
+	for surcharge in tax_slab.surcharge_slabs:
+		if flt(surcharge.min_taxable_income) and flt(surcharge.min_taxable_income) > annual_taxable_earning:
+			continue
+		if flt(surcharge.max_taxable_income) and flt(surcharge.max_taxable_income) < annual_taxable_earning:
+			continue
+		total_surcharge = surcharge_with_marginal_relief(
+			surcharge, tax_amount, annual_taxable_earning, tax_slab, eval_globals, eval_locals
+		)
+
+	return tax_amount + total_surcharge, total_surcharge
+
+
+def surcharge_with_marginal_relief(
+	surcharge, tax_amount, annual_taxable_earning, tax_slab, eval_globals, eval_locals
+):
+	raw_surcharge = tax_amount * flt(surcharge.percent) / 100
+	threshold = flt(surcharge.min_taxable_income)
+	surcharge_rate_previous_slab = get_surcharge_at_previous_slab(threshold, tax_slab)
+
+	base_tax_at_threshold = calculate_base_tax_from_tax_slabs(threshold, tax_slab, eval_globals, eval_locals)
+	surcharge_at_threshold = base_tax_at_threshold * surcharge_rate_previous_slab / 100
+	total_tax_at_threshold = base_tax_at_threshold + surcharge_at_threshold
+
+	excess_income = annual_taxable_earning - threshold
+	excess_tax = (tax_amount + raw_surcharge) - total_tax_at_threshold
+
+	if excess_tax <= excess_income:
+		return raw_surcharge
+	return max(0.0, raw_surcharge - (excess_tax - excess_income))
+
+
+def get_surcharge_at_previous_slab(threshold, tax_slab):
+	tiers = sorted(
+		[c for c in tax_slab.surcharge_slabs],
+		key=lambda c: flt(c.min_taxable_income),
+	)
+	for i, tier in enumerate(tiers):
+		if flt(tier.min_taxable_income) == threshold:
+			return flt(tiers[i - 1].percent) if i > 0 else 0.0
+	return 0.0

--- a/india_payroll/india_payroll/tests/test_india_income_tax.py
+++ b/india_payroll/india_payroll/tests/test_india_income_tax.py
@@ -4,7 +4,6 @@ from hrms.payroll.doctype.income_tax_slab.income_tax_slab import (
 	calculate_base_tax_from_tax_slabs,
 	calculate_other_charges,
 )
-from hrms.payroll.doctype.payroll_period.test_payroll_period import create_payroll_period
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 from hrms.tests.utils import HRMSTestSuite
@@ -199,9 +198,6 @@ class TestIndiaIncomeTax(HRMSTestSuite):
 
 	def test_salary_slip_tds_includes_surcharge(self):
 		"""TDS on a high-income salary slip (₹7.2 M annual) includes the 10% surcharge."""
-		payroll_period = create_payroll_period(
-			name="_Test Payroll Period India Surcharge", company="_Test Company"
-		)
 		employee = make_employee("test_india_surcharge@salary.slip", company="_Test Company")
 
 		salary_structure = make_salary_structure(
@@ -209,7 +205,6 @@ class TestIndiaIncomeTax(HRMSTestSuite):
 			"Monthly",
 			test_tax=True,
 			employee=employee,
-			payroll_period=payroll_period,
 			company="_Test Company",
 			base=600000,  # ₹7.2 M annual — in 10% surcharge band (₹50 L to ₹1 Cr, new regime)
 		)

--- a/india_payroll/india_payroll/tests/test_india_income_tax.py
+++ b/india_payroll/india_payroll/tests/test_india_income_tax.py
@@ -1,0 +1,238 @@
+import frappe
+from erpnext.setup.doctype.employee.test_employee import make_employee
+from hrms.payroll.doctype.income_tax_slab.income_tax_slab import (
+	calculate_base_tax_from_tax_slabs,
+	calculate_other_charges,
+)
+from hrms.payroll.doctype.payroll_period.test_payroll_period import create_payroll_period
+from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
+from hrms.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
+from hrms.tests.utils import HRMSTestSuite
+
+from india_payroll.india_payroll.income_tax_utils import (
+	apply_surcharge_with_marginal_relief,
+	surcharge_with_marginal_relief,
+)
+from india_payroll.install import create_income_tax_slabs
+
+
+class TestIndiaIncomeTax(HRMSTestSuite):
+	def setUp(self):
+		create_income_tax_slabs()
+		self.new_regime_2024 = frappe.get_doc("Income Tax Slab", "New Tax Regime: 2024-2025")
+		self.new_regime_2025 = frappe.get_doc("Income Tax Slab", "New Tax Regime: 2025-2026")
+		self.old_regime = frappe.get_doc("Income Tax Slab", "Old Tax Regime: 2019")
+
+	def test_marginal_relief_applies_at_25pct_threshold(self):
+		"""Income just above ₹2 Cr (25% slab, new regime) — surcharge is reduced by marginal relief."""
+		income = 20125000
+		threshold = 20000001
+		tax_slab = self.new_regime_2024
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		row = surcharge_row("Surcharge 25%", tax_slab)
+
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+		raw_surcharge = base_tax * 25 / 100
+
+		self.assertLess(actual_surcharge, raw_surcharge)
+
+		base_tax_at_threshold = calculate_base_tax_from_tax_slabs(threshold, tax_slab, None, {})
+		surcharge_at_threshold = base_tax_at_threshold * 15 / 100  # prev tier rate
+		tax_at_threshold = base_tax_at_threshold + surcharge_at_threshold
+		excess_income = income - threshold
+
+		self.assertEqual(
+			base_tax + actual_surcharge,
+			tax_at_threshold + excess_income,
+		)
+
+	def test_no_marginal_relief_at_15pct_slab(self):
+		"""Income ₹1.5 Cr (15% slab) — excess income far exceeds excess tax, surcharge unchanged."""
+		income = 15000000
+		tax_slab = self.new_regime_2024
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		row = surcharge_row("Surcharge 15%", tax_slab)
+
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+
+		self.assertEqual(actual_surcharge, base_tax * 15 / 100)
+
+	def test_no_marginal_relief_at_10pct_slab(self):
+		"""Income ₹60 L (10% slab) — no marginal relief needed."""
+		income = 6000000
+		tax_slab = self.new_regime_2024
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		row = surcharge_row("Surcharge 10%", tax_slab)
+
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+
+		self.assertEqual(actual_surcharge, base_tax * 10 / 100)
+
+	def test_old_regime_no_marginal_relief_at_10pct_slab(self):
+		"""Income ₹75 L (old regime, 10% slab) — well inside the band, no marginal relief needed."""
+		income = 7500000
+		tax_slab = self.old_regime
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		row = surcharge_row("Surcharge 10%", tax_slab)
+
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+
+		self.assertEqual(actual_surcharge, base_tax * 10 / 100)
+
+	def test_old_regime_no_marginal_relief_at_15pct_slab(self):
+		"""Income ₹1.5 Cr (old regime, 15% slab) — no marginal relief needed."""
+		income = 15000000
+		tax_slab = self.old_regime
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		row = surcharge_row("Surcharge 15%", tax_slab)
+
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+
+		self.assertEqual(actual_surcharge, base_tax * 15 / 100)
+
+	def test_old_regime_no_marginal_relief_at_25pct_slab(self):
+		"""Income ₹3 Cr (old regime, 25% slab) — no marginal relief needed."""
+		income = 30000000
+		tax_slab = self.old_regime
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		row = surcharge_row("Surcharge 25%", tax_slab)
+
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+
+		self.assertEqual(actual_surcharge, base_tax * 25 / 100)
+
+	def test_old_regime_37pct_surcharge_applies(self):
+		"""Income ₹6 Cr (old regime, 37% tier) — correct tier fires, no marginal relief needed."""
+		income = 60000000
+		tax_slab = self.old_regime
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		row = surcharge_row("Surcharge 37%", tax_slab)
+
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+
+		self.assertEqual(actual_surcharge, base_tax * 37 / 100)
+
+	def test_old_regime_marginal_relief_at_37pct_threshold(self):
+		"""Income just above ₹5 Cr (old regime, 37% slab) — marginal relief reduces surcharge."""
+		income = 50125000
+		threshold = 50000001
+		tax_slab = self.old_regime
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		row = surcharge_row("Surcharge 37%", tax_slab)
+
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+		raw_surcharge = base_tax * 37 / 100
+
+		self.assertLess(actual_surcharge, raw_surcharge)
+
+		base_tax_at_threshold = calculate_base_tax_from_tax_slabs(threshold, tax_slab, None, {})
+		surcharge_at_threshold = base_tax_at_threshold * 25 / 100  # prev tier rate
+		tax_at_threshold = base_tax_at_threshold + surcharge_at_threshold
+		excess_income = income - threshold
+
+		self.assertEqual(base_tax + actual_surcharge, tax_at_threshold + excess_income)
+
+	def test_no_surcharge_below_50_lakh(self):
+		"""Income below ₹50 L — no surcharge slab applies."""
+		income = 4000000
+		tax_slab = self.new_regime_2024
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		tax_with_surcharge, surcharge = apply_surcharge_with_marginal_relief(
+			base_tax, income, tax_slab, None, {}
+		)
+
+		self.assertEqual(surcharge, 0.0)
+		self.assertEqual(tax_with_surcharge, base_tax)
+
+	def test_cess_base_includes_surcharge(self):
+		"""Cess must be applied on (base_tax + surcharge), not on base_tax alone."""
+		income = 6000000
+		tax_slab = self.new_regime_2024
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+		tax_with_surcharge, surcharge = apply_surcharge_with_marginal_relief(
+			base_tax, income, tax_slab, None, {}
+		)
+
+		self.assertEqual(surcharge, base_tax * 10 / 100)
+
+		cess_row = tax_slab.other_taxes_and_charges[0]
+		actual_cess = tax_with_surcharge * cess_row.percent / 100
+		self.assertEqual(actual_cess, tax_with_surcharge * 4 / 100)
+
+	def test_surcharge_in_other_taxes_has_no_marginal_relief(self):
+		"""Surcharge in other_taxes_and_charges is a flat rate — no marginal relief even where it would apply."""
+		income = 20125000  # just above ₹2 Cr — marginal relief applies when in surcharge_slabs
+		tax_slab = self.new_regime_2024
+
+		base_tax = calculate_base_tax_from_tax_slabs(income, tax_slab, None, {})
+
+		# Same 25% rate but placed in other_taxes_and_charges instead of surcharge_slabs
+		mock_slab = frappe._dict(
+			other_taxes_and_charges=[frappe._dict(percent=25, min_taxable_income=0, max_taxable_income=0)]
+		)
+		_, charge = calculate_other_charges(base_tax, income, mock_slab)
+
+		# Flat rate — no relief, unlike the surcharge_slabs path for the same income
+		self.assertEqual(charge, base_tax * 25 / 100)
+
+		# Confirm the surcharge_slabs path DOES apply relief for the same income
+		row = surcharge_row("Surcharge 25%", tax_slab)
+		actual_surcharge = surcharge_with_marginal_relief(row, base_tax, income, tax_slab, None, {})
+		self.assertLess(actual_surcharge, base_tax * 25 / 100)
+
+	def test_new_regime_2025_higher_relief_limit(self):
+		"""New regime 2025-26 relief limit (₹12 L) is higher than 2024-25 (₹7 L)."""
+		income = 900000
+
+		self.assertGreater(self.new_regime_2025.tax_relief_limit, income)
+		self.assertLess(self.new_regime_2024.tax_relief_limit, income)
+
+	def test_salary_slip_tds_includes_surcharge(self):
+		"""TDS on a high-income salary slip (₹7.2 M annual) includes the 10% surcharge."""
+		payroll_period = create_payroll_period(
+			name="_Test Payroll Period India Surcharge", company="_Test Company"
+		)
+		employee = make_employee("test_india_surcharge@salary.slip", company="_Test Company")
+
+		salary_structure = make_salary_structure(
+			"Structure for India Surcharge Test",
+			"Monthly",
+			test_tax=True,
+			employee=employee,
+			payroll_period=payroll_period,
+			company="_Test Company",
+			base=600000,  # ₹7.2 M annual — in 10% surcharge band (₹50 L to ₹1 Cr, new regime)
+		)
+
+		# Ensure the assignment uses India's new-regime slab
+		ssa_name = frappe.db.get_value("Salary Structure Assignment", {"employee": employee, "docstatus": 1})
+		frappe.db.set_value(
+			"Salary Structure Assignment", ssa_name, "income_tax_slab", "New Tax Regime: 2024-2025"
+		)
+
+		salary_slip = make_salary_slip(salary_structure.name, employee=employee)
+
+		tds = next((d.amount for d in salary_slip.deductions if d.salary_component == "TDS"), 0)
+
+		annual_income = salary_slip.annual_taxable_amount
+		base_tax = calculate_base_tax_from_tax_slabs(annual_income, self.new_regime_2024, None, {})
+		_, cess_only = calculate_other_charges(base_tax, annual_income, self.new_regime_2024)
+		no_surcharge_annual_tax = base_tax + cess_only
+
+		self.assertGreater(tds, 0, "Expected non-zero TDS for high-income employee")
+		# Annual TDS must exceed (base_tax + cess-on-base-tax) — proves surcharge was applied
+		self.assertGreater(tds * 12, no_surcharge_annual_tax)
+
+
+def surcharge_row(description, tax_slab):
+	return next(c for c in tax_slab.surcharge_slabs if c.description == description)

--- a/india_payroll/install.py
+++ b/india_payroll/install.py
@@ -41,6 +41,111 @@ INDIA_STATES = [
 ]
 
 
+SURCHARGE_NEW_REGIME = [
+	{
+		"description": "Surcharge 10%",
+		"percent": 10,
+		"min_taxable_income": 5000001,
+		"max_taxable_income": 10000000,
+	},
+	{
+		"description": "Surcharge 15%",
+		"percent": 15,
+		"min_taxable_income": 10000001,
+		"max_taxable_income": 20000000,
+	},
+	{"description": "Surcharge 25%", "percent": 25, "min_taxable_income": 20000001, "max_taxable_income": 0},
+]
+
+SURCHARGE_OLD_REGIME = [
+	{
+		"description": "Surcharge 10%",
+		"percent": 10,
+		"min_taxable_income": 5000001,
+		"max_taxable_income": 10000000,
+	},
+	{
+		"description": "Surcharge 15%",
+		"percent": 15,
+		"min_taxable_income": 10000001,
+		"max_taxable_income": 20000000,
+	},
+	{
+		"description": "Surcharge 25%",
+		"percent": 25,
+		"min_taxable_income": 20000001,
+		"max_taxable_income": 50000000,
+	},
+	{"description": "Surcharge 37%", "percent": 37, "min_taxable_income": 50000001, "max_taxable_income": 0},
+]
+
+CESS = [
+	{
+		"description": "Health & Education Cess",
+		"percent": 4,
+		"min_taxable_income": 0,
+		"max_taxable_income": 0,
+	},
+]
+
+
+INDIA_TAX_SLABS = {
+	"Old Tax Regime: 2019": {
+		"effective_from": "2019-04-01",
+		"currency": "INR",
+		"allow_tax_exemption": 1,
+		"standard_tax_exemption_amount": 50000,
+		"tax_relief_limit": 500000,
+		"marginal_relief_limit": 512500,
+		"slabs": [
+			{"from_amount": 0, "to_amount": 250000, "percent_deduction": 0},
+			{"from_amount": 250001, "to_amount": 500000, "percent_deduction": 5},
+			{"from_amount": 500001, "to_amount": 1000000, "percent_deduction": 20},
+			{"from_amount": 1000001, "to_amount": 0, "percent_deduction": 30},
+		],
+		"surcharge_slabs": SURCHARGE_OLD_REGIME,
+		"other_taxes_and_charges": CESS,
+	},
+	"New Tax Regime: 2024-2025": {
+		"effective_from": "2024-04-01",
+		"currency": "INR",
+		"allow_tax_exemption": 0,
+		"standard_tax_exemption_amount": 75000,
+		"tax_relief_limit": 700000,
+		"marginal_relief_limit": 727777,
+		"slabs": [
+			{"from_amount": 0, "to_amount": 300000, "percent_deduction": 0},
+			{"from_amount": 300001, "to_amount": 700000, "percent_deduction": 5},
+			{"from_amount": 700001, "to_amount": 1000000, "percent_deduction": 10},
+			{"from_amount": 1000001, "to_amount": 1200000, "percent_deduction": 15},
+			{"from_amount": 1200001, "to_amount": 1500000, "percent_deduction": 20},
+			{"from_amount": 1500001, "to_amount": 0, "percent_deduction": 30},
+		],
+		"surcharge_slabs": SURCHARGE_NEW_REGIME,
+		"other_taxes_and_charges": CESS,
+	},
+	"New Tax Regime: 2025-2026": {
+		"effective_from": "2025-04-01",
+		"currency": "INR",
+		"allow_tax_exemption": 0,
+		"standard_tax_exemption_amount": 75000,
+		"tax_relief_limit": 1200000,
+		"marginal_relief_limit": 1275000,
+		"slabs": [
+			{"from_amount": 0, "to_amount": 400000, "percent_deduction": 0},
+			{"from_amount": 400001, "to_amount": 800000, "percent_deduction": 5},
+			{"from_amount": 800001, "to_amount": 1200000, "percent_deduction": 10},
+			{"from_amount": 1200001, "to_amount": 1600000, "percent_deduction": 15},
+			{"from_amount": 1600001, "to_amount": 2000000, "percent_deduction": 20},
+			{"from_amount": 2000001, "to_amount": 2400000, "percent_deduction": 25},
+			{"from_amount": 2400001, "to_amount": 0, "percent_deduction": 30},
+		],
+		"surcharge_slabs": SURCHARGE_NEW_REGIME,
+		"other_taxes_and_charges": CESS,
+	},
+}
+
+
 def get_custom_fields():
 	return {
 		"Payroll Settings": [
@@ -147,6 +252,16 @@ def get_custom_fields():
 				"description": "ESIC wage ceiling is \u20b925,000 instead of \u20b921,000 for persons with disability",
 			},
 		],
+		"Income Tax Slab": [
+			{
+				"fieldname": "surcharge_slabs",
+				"label": "Surcharge Slabs",
+				"fieldtype": "Table",
+				"options": "Income Tax Slab Other Charges",
+				"insert_after": "taxes_and_charges_on_income_tax_section",
+				"reqd": 0,
+			},
+		],
 		"Salary Structure Assignment": [
 			{
 				"fieldname": "employment_state",
@@ -163,6 +278,7 @@ def after_install():
 	create_custom_fields(get_custom_fields())
 	create_professional_tax_component()
 	create_esi_components()
+	create_income_tax_slabs()
 
 
 def after_migrate():
@@ -170,12 +286,6 @@ def after_migrate():
 
 
 def create_professional_tax_component():
-	"""
-	Create the 'Professional Tax' Salary Component if it does not already exist.
-	The component is a plain deduction with no statistical or account settings —
-	the employer must link it to the appropriate GL account per company via
-	Salary Component Account.
-	"""
 	if frappe.db.exists("Salary Component", "Professional Tax"):
 		return
 
@@ -216,3 +326,27 @@ def create_esi_components():
 		}
 	)
 	doc.insert(ignore_permissions=True)
+
+
+def create_income_tax_slabs():
+	for name, data in INDIA_TAX_SLABS.items():
+		if frappe.db.exists("Income Tax Slab", name):
+			continue
+		doc = frappe.new_doc("Income Tax Slab")
+		doc.name = name
+		doc.effective_from = data["effective_from"]
+		doc.currency = data["currency"]
+		doc.allow_tax_exemption = data["allow_tax_exemption"]
+		doc.standard_tax_exemption_amount = data["standard_tax_exemption_amount"]
+		doc.tax_relief_limit = data["tax_relief_limit"]
+		doc.marginal_relief_limit = data["marginal_relief_limit"]
+
+		for row in data["slabs"]:
+			doc.append("slabs", row)
+		for row in data["surcharge_slabs"]:
+			doc.append("surcharge_slabs", row)
+		for row in data["other_taxes_and_charges"]:
+			doc.append("other_taxes_and_charges", row)
+
+		doc.insert(ignore_permissions=True)
+		doc.submit()


### PR DESCRIPTION
Closes #8

- Explanation for marginal relief is over at frappe/hrms#4575 on which this PR depends. `apply_surcharge_with_marginal_relief` method in IP overrides the one in hrms to apply surcharge with marginal relief.

- Income tax slabs for New and Old tax regimes are created on install, the effective from date for the Old Tax regime is kept at the start of 2019 financial year. Previous revision of  tax slabs for New Tax Regime live in "New Tax Regime: 2024-2025" while the new ones are in "New Tax Regime: 2025-2026". Naming for Old Tax is "Old Tax Regime: 2019"

https://github.com/user-attachments/assets/7d918c42-33ef-45a5-ad0a-d55765a1e136


- And tests