### PR TITLE
feat(report): add Professional Tax Register

### DIFF
--- a/india_payroll/india_payroll/report/professional_tax_register/professional_tax_register.js
+++ b/india_payroll/india_payroll/report/professional_tax_register/professional_tax_register.js
@@ -1,0 +1,151 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+const MONTHS = [
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December",
+];
+
+// States that levy Professional Tax (must stay in sync with STATE_PT_CONFIG in professional_tax.py)
+const PT_STATES = [
+	"Andhra Pradesh",
+	"Assam",
+	"Bihar",
+	"Gujarat",
+	"Jharkhand",
+	"Karnataka",
+	"Kerala",
+	"Madhya Pradesh",
+	"Maharashtra",
+	"Meghalaya",
+	"Odisha",
+	"Sikkim",
+	"Tamil Nadu",
+	"Telangana",
+	"Tripura",
+	"West Bengal",
+];
+
+function _yearOptions() {
+	const current = new Date().getFullYear();
+	const options = [];
+	for (let y = current - 3; y <= current + 1; y++) options.push(String(y));
+	return options.join("\n");
+}
+
+frappe.query_reports["Professional Tax Register"] = {
+	filters: [
+		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			options: "Company",
+			reqd: 1,
+			default: frappe.defaults.get_user_default("Company"),
+		},
+		{
+			fieldname: "year",
+			label: __("Year"),
+			fieldtype: "Select",
+			options: _yearOptions(),
+			default: String(new Date().getFullYear()),
+			reqd: 1,
+		},
+		{
+			fieldname: "month",
+			label: __("Month"),
+			fieldtype: "Select",
+			options: "\n" + MONTHS.join("\n"),
+			default: MONTHS[new Date().getMonth()],
+		},
+		{
+			fieldname: "work_state",
+			label: __("Work State"),
+			fieldtype: "Select",
+			options: "\n" + PT_STATES.join("\n"),
+			description: __("Filter by employee work state"),
+		},
+		{
+			fieldname: "deduction_status",
+			label: __("Deduction Status"),
+			fieldtype: "Select",
+			options: "\nDeducted\nNil\nNo PT State",
+		},
+	],
+
+	formatter(value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+		if (column.fieldname === "deduction_status" && data) {
+			const colours = {
+				Deducted: "#2d8a2d",
+				Nil: "#888",
+				"No PT State": "#aaa",
+			};
+			const bg = colours[data.deduction_status] || "#888";
+			value = `<span style="background:${bg};color:#fff;border-radius:10px;
+				padding:1px 10px;font-size:0.8em;white-space:nowrap;">${data.deduction_status}</span>`;
+		}
+		if (column.fieldname === "frequency" && data && data.frequency) {
+			value = `<span style="font-size:0.85em;color:#555;">${data.frequency}</span>`;
+		}
+		return value;
+	},
+
+	onload(report) {
+		report.page.add_inner_button(__("Export for PT Remittance"), () => {
+			const data = frappe.query_report.data;
+			if (!data || !data.length) {
+				frappe.msgprint(__("No data to export."));
+				return;
+			}
+
+			const headers = [
+				"Employee",
+				"Department",
+				"Designation",
+				"Work State",
+				"PT Frequency",
+				"Gross Wages",
+				"Professional Tax",
+				"Deduction Status",
+			];
+
+			const csvRows = [headers.join(",")];
+			data.forEach((row) => {
+				csvRows.push(
+					[
+						row.employee || "",
+						`"${(row.department || "").replace(/"/g, '""')}"`,
+						`"${(row.designation || "").replace(/"/g, '""')}"`,
+						`"${(row.work_state || "").replace(/"/g, '""')}"`,
+						row.frequency || "",
+						flt(row.gross_wages, 2),
+						flt(row.professional_tax, 2),
+						row.deduction_status || "",
+					].join(",")
+				);
+			});
+
+			const blob = new Blob([csvRows.join("\n")], { type: "text/csv;charset=utf-8;" });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			const company = frappe.query_report.get_filter_value("company") || "PT";
+			const month = frappe.query_report.get_filter_value("month") || "";
+			const year = frappe.query_report.get_filter_value("year") || "";
+			a.href = url;
+			a.download = `PT_Register_${company}_${month}_${year}.csv`.replace(/\s+/g, "_");
+			a.click();
+			URL.revokeObjectURL(url);
+		});
+	},
+};

--- a/india_payroll/india_payroll/report/professional_tax_register/professional_tax_register.json
+++ b/india_payroll/india_payroll/report/professional_tax_register/professional_tax_register.json
@@ -1,0 +1,30 @@
+{
+ "add_total_row": 1,
+ "creation": "2026-06-11 00:00:00.000000",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2026-06-11 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "India Payroll",
+ "name": "Professional Tax Register",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Salary Slip",
+ "report_name": "Professional Tax Register",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "HR Manager"
+  },
+  {
+   "role": "HR User"
+  },
+  {
+   "role": "Payroll Manager"
+  }
+ ]
+}

--- a/india_payroll/india_payroll/report/professional_tax_register/professional_tax_register.py
+++ b/india_payroll/india_payroll/report/professional_tax_register/professional_tax_register.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.query_builder import DocType
+from frappe.utils import flt
+
+from india_payroll.india_payroll.professional_tax import PT_SALARY_COMPONENT, STATE_PT_CONFIG
+
+_MONTHS = {
+	"January": 1,
+	"February": 2,
+	"March": 3,
+	"April": 4,
+	"May": 5,
+	"June": 6,
+	"July": 7,
+	"August": 8,
+	"September": 9,
+	"October": 10,
+	"November": 11,
+	"December": 12,
+}
+
+
+def execute(filters=None):
+	filters = filters or {}
+	columns = get_columns()
+	data = get_data(filters)
+	return columns, data
+
+
+def get_columns():
+	return [
+		{
+			"label": _("Employee"),
+			"fieldname": "employee",
+			"fieldtype": "Link",
+			"options": "Employee",
+			"width": 110,
+		},
+		{
+			"label": _("Department"),
+			"fieldname": "department",
+			"fieldtype": "Link",
+			"options": "Department",
+			"width": 140,
+		},
+		{
+			"label": _("Designation"),
+			"fieldname": "designation",
+			"fieldtype": "Link",
+			"options": "Designation",
+			"width": 140,
+		},
+		{
+			"label": _("Work State"),
+			"fieldname": "work_state",
+			"fieldtype": "Data",
+			"width": 140,
+		},
+		{
+			"label": _("PT Frequency"),
+			"fieldname": "frequency",
+			"fieldtype": "Data",
+			"width": 110,
+		},
+		{
+			"label": _("Gross Wages"),
+			"fieldname": "gross_wages",
+			"fieldtype": "Currency",
+			"options": "currency",
+			"width": 130,
+		},
+		{
+			"label": _("Professional Tax (₹)"),
+			"fieldname": "professional_tax",
+			"fieldtype": "Currency",
+			"options": "currency",
+			"width": 160,
+		},
+		{
+			"label": _("Deduction Status"),
+			"fieldname": "deduction_status",
+			"fieldtype": "Data",
+			"width": 150,
+		},
+		{
+			"label": _("Currency"),
+			"fieldname": "currency",
+			"fieldtype": "Data",
+			"width": 60,
+			"hidden": 1,
+		},
+	]
+
+
+def get_data(filters):
+	date_range = _get_date_range(filters)
+	state_filter = filters.get("work_state")
+	status_filter = filters.get("deduction_status")
+
+	SS = DocType("Salary Slip")
+	Emp = DocType("Employee")
+
+	query = (
+		frappe.qb.from_(SS)
+		.join(Emp)
+		.on(Emp.name == SS.employee)
+		.select(
+			SS.name,
+			SS.employee,
+			SS.start_date,
+			SS.salary_structure,
+			SS.company,
+			SS.gross_pay,
+			SS.currency,
+			Emp.department,
+			Emp.designation,
+		)
+		.where(SS.docstatus == 1)
+	)
+
+	if filters.get("company"):
+		query = query.where(SS.company == filters["company"])
+
+	if date_range:
+		query = query.where(SS.start_date >= date_range["from_date"])
+		query = query.where(SS.start_date <= date_range["to_date"])
+
+	rows = query.run(as_dict=True)
+
+	data = []
+	for row in rows:
+		# Resolve employment_state from the effective Salary Structure Assignment
+		work_state = frappe.db.get_value(
+			"Salary Structure Assignment",
+			filters={
+				"employee": row.employee,
+				"company": row.company,
+				"salary_structure": row.salary_structure,
+				"from_date": ("<=", row.start_date),
+			},
+			fieldname="employment_state",
+			order_by="from_date desc",
+		)
+
+		if state_filter and work_state != state_filter:
+			continue
+
+		# Actual Professional Tax deducted on this slip — the challan basis is what
+		# was really withheld (handles half-yearly months, Feb rule, exemptions, etc.)
+		pt_amount = flt(
+			sum(
+				frappe.get_all(
+					"Salary Detail",
+					filters={
+						"parent": row.name,
+						"parentfield": "deductions",
+						"salary_component": PT_SALARY_COMPONENT,
+					},
+					pluck="amount",
+				)
+			),
+			2,
+		)
+
+		if not work_state or work_state not in STATE_PT_CONFIG:
+			deduction_status = "No PT State"
+			frequency = ""
+		else:
+			frequency = STATE_PT_CONFIG[work_state]["frequency"].title()
+			deduction_status = "Deducted" if pt_amount else "Nil"
+
+		if status_filter and deduction_status != status_filter:
+			continue
+
+		data.append(
+			{
+				"employee": row.employee,
+				"department": row.get("department") or "",
+				"designation": row.get("designation") or "",
+				"work_state": work_state or "",
+				"frequency": frequency,
+				"gross_wages": flt(row.gross_pay),
+				"professional_tax": pt_amount,
+				"deduction_status": deduction_status,
+				"currency": row.currency or "INR",
+			}
+		)
+
+	return data
+
+
+def _get_date_range(filters):
+	"""
+	Derive a start_date range from the report filters.
+
+	Priority:
+	  1. Month + Year  (single month)
+	  2. No date filter (all submitted slips)
+	"""
+	year = filters.get("year")
+	month_name = filters.get("month")
+
+	if year and month_name and month_name in _MONTHS:
+		import calendar
+
+		month_num = _MONTHS[month_name]
+		year_int = int(year)
+		last_day = calendar.monthrange(year_int, month_num)[1]
+		return {
+			"from_date": f"{year_int:04d}-{month_num:02d}-01",
+			"to_date": f"{year_int:04d}-{month_num:02d}-{last_day:02d}",
+		}
+
+	return None

--- a/india_payroll/india_payroll/report/professional_tax_register/test_professional_tax_register.py
+++ b/india_payroll/india_payroll/report/professional_tax_register/test_professional_tax_register.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from erpnext.setup.doctype.employee.test_employee import make_employee
+from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
+from hrms.payroll.doctype.salary_structure.test_salary_structure import (
+	create_salary_structure_assignment,
+	make_salary_structure,
+)
+from hrms.tests.utils import HRMSTestSuite
+
+from india_payroll.india_payroll.report.professional_tax_register.professional_tax_register import (
+	execute,
+)
+from india_payroll.install import create_professional_tax_component
+
+
+class TestProfessionalTaxRegister(HRMSTestSuite):
+	def setUp(self):
+		create_professional_tax_component()
+
+	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_professional_tax": 1})
+	def test_maharashtra_employee_shown_as_deducted(self):
+		"""A submitted Maharashtra slip appears with ₹200 PT, Monthly, Deducted."""
+		row = self._register_row_for_maharashtra_employee()
+		self.assertEqual(row["work_state"], "Maharashtra")
+		self.assertEqual(row["frequency"], "Monthly")
+		self.assertEqual(row["professional_tax"], 200)
+		self.assertEqual(row["deduction_status"], "Deducted")
+
+	def _register_row_for_maharashtra_employee(self):
+		employee = make_employee(
+			"test_pt_register@indiapayroll.com", company="_Test Company", gender="Male"
+		)
+		salary_structure = make_salary_structure(
+			"Test PT Register Structure", "Monthly",
+			employee=employee, company="_Test Company", currency="INR",
+		)
+		assignment = create_salary_structure_assignment(
+			employee, salary_structure.name, from_date="2026-04-01", company="_Test Company"
+		)
+		frappe.db.set_value(
+			"Salary Structure Assignment", assignment.name, "employment_state", "Maharashtra"
+		)
+
+		salary_slip = make_salary_slip(
+			salary_structure.name, employee=employee, posting_date="2026-04-01"
+		)
+		salary_slip.start_date = "2026-04-01"
+		salary_slip.end_date = "2026-04-30"
+		salary_slip.insert()
+		salary_slip.submit()
+
+		_columns, data = execute({"company": "_Test Company", "year": "2026", "month": "April"})
+		return next(row for row in data if row["employee"] == employee)


### PR DESCRIPTION
## What

Adds a **Professional Tax Register** Script Report, the missing sibling to the existing **ESIC Register** and **LWF Register**. india_payroll injects PT as a state-wise statutory deduction but ships no register to review/remit it.

## How

- Per-employee PT for a period; **work state** and **frequency** resolved from `STATE_PT_CONFIG`.
- **Professional Tax** read as the *actual amount withheld* on the submitted Salary Slip — the real challan basis, so it correctly reflects half-yearly months, the Maharashtra February rule, and exemptions (no recomputation drift).
- Filters: company, year, month, work state, deduction status.
- Deduction status: `Deducted` / `Nil` / `No PT State`. The last flags employees who had PT withheld but have no `employment_state` set — so the remittance state is visible and fixable.
- `Export for PT Remittance` CSV button and `add_total_row` for challan totals.
- Roles match the other registers (HR Manager / HR User / Payroll Manager).

Follows the `lwf_register` conventions exactly (query-builder, filter-driven date range, JS export button).

## Testing

Ran `execute()` against real submitted slips: Maharashtra employees show `Deducted · Monthly · ₹200`; employees with PT withheld but no state set are correctly surfaced as `No PT State`; totals reconcile.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)