### PR TITLE
fix(tax-regime-selector): UI polish and bug fixes

### DIFF
--- a/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.js
+++ b/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.js
@@ -1,8 +1,45 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
+// India Payroll has no workspace, so frappe.breadcrumbs cannot natively show a
+// "parent > page" trail here: a Custom breadcrumb renders a single link, and
+// frappe.container.change_to() re-runs breadcrumbs.update() on every show (and on
+// cold load), which re-renders only the single stored crumb - dropping anything we
+// append afterwards. So wrap update() once: whenever this page is active, rebuild the
+// breadcrumb deterministically as Home > Tax & Benefits > Tax Regime Selector. This
+// survives a hard refresh and in-app navigation alike.
+(function patch_tax_regime_breadcrumb() {
+	if (frappe.breadcrumbs._trs_patched) return;
+	frappe.breadcrumbs._trs_patched = true;
+
+	const orig_update = frappe.breadcrumbs.update.bind(frappe.breadcrumbs);
+	frappe.breadcrumbs.update = function () {
+		orig_update();
+		if (frappe.get_route_str() !== "tax-regime-selector") return;
+		this.$breadcrumbs = $(".navbar-breadcrumbs").empty();
+		this.append_breadcrumb_element("/desk", frappe.utils.icon("home"));
+		this.append_breadcrumb_element(
+			"/app/" + frappe.router.slug("Tax & Benefits"),
+			__("Tax & Benefits")
+		);
+		this.append_breadcrumb_element("", __("Tax Regime Selector"));
+		this.toggle(true);
+	};
+})();
+
 frappe.pages["tax-regime-selector"].on_page_load = function (wrapper) {
 	frappe.require(["tax_regime_selector.bundle.js", "tax_regime_selector.bundle.css"], () => {
 		new window.india_payroll.ui.TaxRegimeSelector(wrapper);
+		// The .navbar-breadcrumbs element lives in the page header built by
+		// make_app_page (run inside the controller above). On a cold load this require
+		// callback is async and runs after on_page_show, so the breadcrumb element does
+		// not exist yet when on_page_show fires - render it now that it does.
+		frappe.breadcrumbs.update();
 	});
+};
+
+// Re-render on every show (covers in-app revisits, where the controller above is not
+// re-instantiated). The wrapped update() builds the trail.
+frappe.pages["tax-regime-selector"].on_page_show = function () {
+	frappe.breadcrumbs.update();
 };

--- a/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.py
+++ b/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.py
@@ -6,15 +6,22 @@ from datetime import date
 
 import frappe
 from frappe.utils import flt, getdate
-from hrms.payroll.doctype.income_tax_slab.income_tax_slab import calculate_tax_by_tax_slab
-from hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignment import (
-	PERIODS_PER_YEAR,
-)
+from hrms.payroll.doctype.salary_slip.salary_slip import calculate_tax_by_tax_slab
 
 from india_payroll.india_payroll.tax_exemption_setup import (
 	EXEMPTION_CATEGORIES,
 	setup_tax_exemption_categories,
 )
+
+# Payroll periods per year by Salary Structure payroll frequency. Kept local so the
+# page does not depend on an HRMS internal constant (which has moved/been removed).
+PERIODS_PER_YEAR = {
+	"Monthly": 12,
+	"Fortnightly": 26,
+	"Bimonthly": 24,
+	"Weekly": 52,
+	"Daily": 365,
+}
 
 OLD_REGIME_SLAB = "Old Tax Regime: 2019"
 NEW_REGIME_SLAB = "New Tax Regime: 2025-2026"
@@ -161,8 +168,11 @@ def compute_tax_comparison(
 	old_slab = frappe.get_doc("Income Tax Slab", OLD_REGIME_SLAB)
 	new_slab = frappe.get_doc("Income Tax Slab", NEW_REGIME_SLAB)
 
-	old_tax, _ = calculate_tax_by_tax_slab(old_taxable, old_slab)
-	new_tax, _ = calculate_tax_by_tax_slab(new_taxable, new_slab)
+	# Pass empty eval dicts: the standard slabs carry no row conditions, but the HRMS
+	# helper does eval_locals.update(...) for incomes above tax_relief_limit and would
+	# fail on the default None.
+	old_tax, _ = calculate_tax_by_tax_slab(old_taxable, old_slab, {}, {})
+	new_tax, _ = calculate_tax_by_tax_slab(new_taxable, new_slab, {}, {})
 
 	return {
 		"old_regime": {
@@ -235,8 +245,10 @@ def notify_employee_to_select_tax_regime(assignment: str) -> dict:
 		message=frappe._(
 			"Dear {0},<br><br>"
 			"Please select your preferred income tax regime for the current payroll period "
-			"using the Tax Regime Selector:<br><br>"
-			'<a href="{1}">Open Tax Regime Selector</a><br><br>'
+			"using the Tax Regime Selector:"
+			'<p style="margin: 15px 0px;">'
+			'<a href="{1}" class="btn btn-primary" target="_blank">Open Tax Regime Selector</a>'
+			"</p>"
 			"Regards,<br>HR Team"
 		).format(ssa.employee_name or "", link),
 		reference_doctype="Salary Structure Assignment",

--- a/india_payroll/public/js/tax_regime_selector/comparison.js
+++ b/india_payroll/public/js/tax_regime_selector/comparison.js
@@ -15,10 +15,20 @@ export function renderComparison(ctrl, result) {
 
 	// A regime choice rendered as a radio card. Picking it stages the choice; the
 	// staged card gets a colored border (green, or blue on a tie). Label precedence
-	// is Selected > Suggested/Default.
+	// is Selected > Suggested/Default. The regime in force is the saved choice (when
+	// it still matches a current card), or - on a submitted/locked SSA with nothing
+	// valid saved - New Regime as the system default.
 	const regime_card = (label, regime, is_winner, tie_pill) => {
 		const is_staged = ctrl.staged_slab === regime.slab;
-		const is_selected = ctrl.selected_slab === regime.slab;
+		// The saved regime, but only if it still matches one of the two cards. A blank
+		// field - or a stale/unknown slab name - counts as "nothing saved".
+		const saved_slab =
+			ctrl.selected_slab === old.slab || ctrl.selected_slab === new_.slab
+				? ctrl.selected_slab
+				: null;
+		// Drafts keep no default so the employee actively picks one.
+		const effective_slab = saved_slab || (ctrl.is_submitted ? new_.slab : null);
+		const is_selected = effective_slab && regime.slab === effective_slab;
 
 		let pill_color = "";
 		let pill_label = "";
@@ -26,7 +36,9 @@ export function renderComparison(ctrl, result) {
 			pill_color = "green";
 			pill_label = __("Selected");
 		} else if (is_tie) {
-			if (tie_pill) {
+			// Blue "Default" marks New as the tie-breaker default, only while no valid
+			// regime is saved - never override an explicit, matching choice.
+			if (tie_pill && !saved_slab) {
 				pill_color = "blue";
 				pill_label = __("Default");
 			}
@@ -39,7 +51,10 @@ export function renderComparison(ctrl, result) {
 			? `<span class="badge indicator-pill ${pill_color} no-indicator-dot" style="flex-shrink:0;">${pill_label}</span>`
 			: "";
 
-		const border = is_staged
+		// In draft the staged radio drives the border; on a submitted SSA there is no
+		// staging, so the in-force (selected) card carries the highlight instead.
+		const is_highlighted = is_staged || (ctrl.is_submitted && is_selected);
+		const border = is_highlighted
 			? is_tie
 				? "var(--blue-500)"
 				: "var(--green-500)"
@@ -54,7 +69,9 @@ export function renderComparison(ctrl, result) {
 			  } style="width:16px; height:16px; margin:0; flex-shrink:0;">`;
 
 		return `
-		<label class="regime-radio-card frappe-card" style="flex:1 1 200px; min-width:200px; max-width:100%; margin:0; padding:14px 16px; ${
+		<label class="regime-radio-card${
+			ctrl.is_submitted ? " no-hover" : ""
+		} frappe-card" style="flex:1 1 200px; min-width:200px; max-width:100%; margin:0; padding:14px 16px; ${
 			ctrl.is_submitted ? "" : "cursor:pointer;"
 		} display:block;
 			border:1px solid ${border};">
@@ -96,8 +113,10 @@ export function renderComparison(ctrl, result) {
 	$("#comparison-alert").html("");
 
 	// Save Regime lives in the page toolbar (top-right); shown only for editable
-	// (draft) assignments when a regime is selected. Submitted SSAs are read-only.
-	if (ctrl.staged_slab && !ctrl.is_submitted) {
+	// (draft) assignments once the staged choice is a real, current regime. A stale
+	// staged slab keeps it hidden until the user picks one. Submitted SSAs are read-only.
+	const staged_valid = ctrl.staged_slab === old.slab || ctrl.staged_slab === new_.slab;
+	if (staged_valid && !ctrl.is_submitted) {
 		ctrl.page.set_primary_action(__("Save Regime"), () => ctrl.save_regime());
 	} else {
 		ctrl.page.clear_primary_action();
@@ -108,7 +127,7 @@ export function renderComparison(ctrl, result) {
 			${regime_card(__("Old Regime"), old, !is_tie && old_wins, false)}
 			${regime_card(__("New Regime"), new_, !is_tie && !old_wins, true)}
 		</div>
-		<div class="form-message ${alert_color}" style="margin-bottom:12px; font-weight:normal; margin-right:15px; flex-shrink:0;">
+		<div class="form-message ${alert_color}" style="margin-bottom:12px; font-weight:normal; margin-right:15px; flex-shrink:0; border-radius:var(--border-radius);">
 			${winner_label}
 		</div>
 		<div style="display:flex; flex-direction:column; border:1px solid var(--border-color); border-radius:var(--border-radius); overflow:hidden; font-size:var(--text-sm); margin-right:15px; flex:1; min-height:0;">

--- a/india_payroll/public/js/tax_regime_selector/templates.js
+++ b/india_payroll/public/js/tax_regime_selector/templates.js
@@ -60,9 +60,12 @@ export function mainLayout(hasHra) {
 	return `
 		<div style="display:flex; gap:15px; align-items:flex-start;">
 			<div style="flex:0 0 65%; max-width:65%; min-width:0;">
-				<div class="frappe-card" style="padding: 16px; max-height:80vh; display:flex; flex-direction:column;">
-					<div style="display:flex; justify-content:flex-end; flex-shrink:0; margin-bottom:12px;">
-						<button class="btn btn-default btn-sm declare-btn">
+				<div class="frappe-card" style="padding: 16px; max-height:calc(80vh + 1rem); display:flex; flex-direction:column;">
+					<div style="display:flex; justify-content:space-between; align-items:center; gap:12px; flex-shrink:0; margin-bottom:16px;">
+						<span style="font-size:var(--text-lg); font-weight:600;">${__(
+							"Add your exemptions to compare tax in both regimes"
+						)}</span>
+						<button class="btn btn-default btn-sm declare-btn" style="white-space:nowrap;">
 							${__("Declare Tax Exemptions →")}
 						</button>
 					</div>
@@ -82,8 +85,8 @@ export function mainLayout(hasHra) {
 							)}</h6>
 							<div style="display:flex; align-items:center; gap:8px;">
 								<div style="position:relative;" id="declaration-search-wrapper">
-									<span style="position:absolute; left:8px; top:50%; transform:translateY(-50%); display:inline-flex; color:var(--text-muted); pointer-events:none;">
-										<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+									<span style="position:absolute; left:8px; top:50%; transform:translateY(-50%); display:inline-flex; color:var(--gray-500); --icon-stroke:var(--gray-500); pointer-events:none; z-index:2;">
+										${frappe.utils.icon("search", "sm")}
 									</span>
 									<input type="text" class="form-control input-sm" id="declaration-search"
 										placeholder="${__("Search")}" style="padding-left:28px;">
@@ -99,7 +102,7 @@ export function mainLayout(hasHra) {
 					</div>
 				</div>
 			</div>
-			<div style="flex:0 0 35%; max-width:35%; min-width:0; position:sticky; top:0; margin-right:15px; max-height:80vh; display:flex; flex-direction:column;" id="comparison-panel">
+			<div style="flex:0 0 35%; max-width:35%; min-width:0; position:sticky; top:0; margin-right:15px; max-height:calc(80vh + 1rem); display:flex; flex-direction:column;" id="comparison-panel">
 				<div class="text-center text-muted" style="padding: 40px 0;">
 					${__("Computing...")}
 				</div>

--- a/india_payroll/public/scss/tax_regime_selector.bundle.scss
+++ b/india_payroll/public/scss/tax_regime_selector.bundle.scss
@@ -1,9 +1,20 @@
 .regime-radio-card {
 	transition: box-shadow 0.1s;
 }
-.regime-radio-card:hover {
+/* Submitted SSAs render read-only cards (.no-hover); skip the hover ring for them. */
+.regime-radio-card:not(.no-hover):hover {
 	box-shadow: 0 0 0 1px var(--gray-400);
 }
 .section-header-row:hover {
 	background: var(--gray-50);
+}
+
+/* The top filter controls render a .form-group with Bootstrap's default
+   margin-bottom: 1rem, adding dead space below the row. Drop it so the page body
+   (the comparison cards) sits tighter; the card/panel max-height is bumped by 1rem
+   to keep the bottom border where it was. */
+#payroll-period-wrapper .form-group,
+#employee-field-wrapper .form-group,
+#annual-gross-wrapper .form-group {
+	margin-bottom: 0;
 }


### PR DESCRIPTION
Uploading tax-regime-2.mp4…

Detailed changes

Pill / selection logic (comparison.js):
- Show "Selected" on the in-force regime: the saved slab, or New Regime as the
  default on a submitted SSA with nothing saved (was wrongly showing "Suggested").
- Treat a stale/unknown saved slab (no match to either card) as empty -> "Suggested".
- Show the blue tie "Default" pill only when no valid regime is saved, so it no
  longer overrides an explicit choice.
- Highlight the selected card's border on submitted SSAs; gate the Save Regime
  button on a valid staged slab; restore the no-hover class so submitted (read-only)
  cards show no hover ring (and restore the :not(.no-hover) gate in scss).

Backend (tax_regime_selector.py) - 
- Import calculate_tax_by_tax_slab from salary_slip (moved out of income_tax_slab).
- Inline PERIODS_PER_YEAR locally (removed from salary_structure_assignment).
- Pass empty eval dicts to calculate_tax_by_tax_slab to avoid a None crash above
  the slab relief limit.
- Render the notification email CTA as a btn btn-primary button.

Breadcrumb (tax_regime_selector.js):
- Show "Home > Tax & Benefits > Tax Regime Selector". India Payroll has no
  workspace, so wrap breadcrumbs.update() (route-guarded) to rebuild the trail on
  every render, and trigger it after make_app_page creates the element so it also
  holds on a cold refresh (not just in-app navigation).

UI polish (templates.js, scss):
- Fix the invisible search icon (stacking: positioned .form-control painted over it)
  with z-index, use frappe.utils.icon, and dampen it to --gray-500.
- Add a title above the deductions card: "Add your exemptions to compare tax in
  both regimes".
- Round the savings alert card corners.
- Drop the filter-row form-group bottom margin and add 1rem to the card/panel
  max-height so the comparison cards sit tighter with bottom borders aligned.