### PR TITLE
fix: UI polishing

### DIFF
--- a/india_payroll/public/js/tax_regime_selector/comparison.js
+++ b/india_payroll/public/js/tax_regime_selector/comparison.js
@@ -30,11 +30,19 @@ export function renderComparison(ctrl, result) {
 		const effective_slab = saved_slab || (ctrl.is_submitted ? new_.slab : null);
 		const is_selected = effective_slab && regime.slab === effective_slab;
 
+		// True when the suggested (winning) regime sits on a different card than the
+		// in-force one - i.e. the recommendation disagrees with the current choice.
+		const winner_slab = is_tie ? null : old_wins ? old.slab : new_.slab;
+		const selected_differs = !!effective_slab && !is_tie && effective_slab !== winner_slab;
+
 		let pill_color = "";
 		let pill_label = "";
 		if (is_selected) {
-			pill_color = "green";
 			pill_label = __("Selected");
+			// Blue (neutral) in a tie - neither regime is cheaper, so green would falsely
+			// claim "optimal" - or on an editable SSA where the recommendation differs (a
+			// distinct green "Suggested" sits alongside). Otherwise the lone choice is green.
+			pill_color = is_tie || (selected_differs && !ctrl.is_submitted) ? "blue" : "green";
 		} else if (is_tie) {
 			// Blue "Default" marks New as the tie-breaker default, only while no valid
 			// regime is saved - never override an explicit, matching choice.
@@ -43,8 +51,12 @@ export function renderComparison(ctrl, result) {
 				pill_label = __("Default");
 			}
 		} else if (is_winner) {
-			pill_color = "green";
-			pill_label = __("Suggested");
+			// On a submitted SSA the employee can't switch, so the "Suggested" pill is just
+			// noise when it disagrees with the locked-in choice - drop it.
+			if (!(ctrl.is_submitted && selected_differs)) {
+				pill_color = "green";
+				pill_label = __("Suggested");
+			}
 		}
 
 		const pill_html = pill_label
@@ -52,10 +64,11 @@ export function renderComparison(ctrl, result) {
 			: "";
 
 		// In draft the staged radio drives the border; on a submitted SSA there is no
-		// staging, so the in-force (selected) card carries the highlight instead.
+		// staging, so the in-force (selected) card carries the highlight instead. The
+		// highlight follows the pill color so the blue "Selected" card gets a blue border.
 		const is_highlighted = is_staged || (ctrl.is_submitted && is_selected);
 		const border = is_highlighted
-			? is_tie
+			? pill_color === "blue" || is_tie
 				? "var(--blue-500)"
 				: "var(--green-500)"
 			: "var(--border-color)";
@@ -112,11 +125,14 @@ export function renderComparison(ctrl, result) {
 
 	$("#comparison-alert").html("");
 
-	// Save Regime lives in the page toolbar (top-right); shown only for editable
-	// (draft) assignments once the staged choice is a real, current regime. A stale
+	// Save Regime lives in the page toolbar (top-right); behaves like Frappe's dirty
+	// indicator. Shown only for editable (draft) assignments when the staged choice is a
+	// real, current regime that differs from the one already saved - so it hides after a
+	// save (feedback) and reappears the moment a different regime is picked. A stale
 	// staged slab keeps it hidden until the user picks one. Submitted SSAs are read-only.
 	const staged_valid = ctrl.staged_slab === old.slab || ctrl.staged_slab === new_.slab;
-	if (staged_valid && !ctrl.is_submitted) {
+	const is_dirty = ctrl.staged_slab !== ctrl.selected_slab;
+	if (staged_valid && is_dirty && !ctrl.is_submitted) {
 		ctrl.page.set_primary_action(__("Save Regime"), () => ctrl.save_regime());
 	} else {
 		ctrl.page.clear_primary_action();

--- a/india_payroll/public/js/tax_regime_selector/controller.js
+++ b/india_payroll/public/js/tax_regime_selector/controller.js
@@ -179,6 +179,13 @@ export class TaxRegimeSelector {
 		$("#page-body").html(mainLayout(this.employee_data.has_hra));
 		this.bind_input_events();
 		setupDeclarationTable(this);
+
+		// The card scrolls as a whole; the heading row is sticky at the top and the table
+		// header sticks right below it. Publish the heading's height so the thead's sticky
+		// offset (--trs-header-h) parks it under the heading instead of overlapping.
+		const card = document.querySelector("#page-body .frappe-card");
+		const heading = card?.firstElementChild;
+		if (card && heading) card.style.setProperty("--trs-header-h", heading.offsetHeight + "px");
 	}
 
 	bind_input_events() {

--- a/india_payroll/public/js/tax_regime_selector/declarations.js
+++ b/india_payroll/public/js/tax_regime_selector/declarations.js
@@ -75,6 +75,8 @@ export function setupDeclarationTable(ctrl) {
 		<style>
 			.declaration-input::-webkit-outer-spin-button,
 			.declaration-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+			.declaration-table thead th:first-child { border-top-left-radius: var(--border-radius); }
+			.declaration-table thead th:last-child { border-top-right-radius: var(--border-radius); }
 		</style>
 		<table style="width:100%; table-layout:fixed; border-collapse:collapse;" class="declaration-table">
 			<colgroup>
@@ -84,13 +86,13 @@ export function setupDeclarationTable(ctrl) {
 			</colgroup>
 			<thead>
 				<tr>
-					<th style="padding:10px 12px; font-weight:500; color:var(--text-muted); position:sticky; top:-1px; z-index:1; background:var(--gray-50); box-shadow:inset 0 -2px 0 var(--border-color);">${__(
+					<th style="padding:10px 12px; font-weight:500; color:var(--text-muted); position:sticky; top:calc(var(--trs-header-h, 0px) - 1px); z-index:1; background:var(--gray-50); box-shadow:inset 0 -2px 0 var(--border-color);">${__(
 						"Deduction / Investment"
 					)}</th>
-					<th style="padding:10px 12px; font-weight:500; color:var(--text-muted); text-align:right; position:sticky; top:-1px; z-index:1; background:var(--gray-50); box-shadow:inset 0 -2px 0 var(--border-color);">${__(
+					<th style="padding:10px 12px; font-weight:500; color:var(--text-muted); text-align:right; position:sticky; top:calc(var(--trs-header-h, 0px) - 1px); z-index:1; background:var(--gray-50); box-shadow:inset 0 -2px 0 var(--border-color);">${__(
 						"Limit"
 					)}</th>
-					<th style="padding:10px 12px; font-weight:500; color:var(--text-muted); text-align:right; position:sticky; top:-1px; z-index:1; background:var(--gray-50); box-shadow:inset 0 -2px 0 var(--border-color);">${__(
+					<th style="padding:10px 12px; font-weight:500; color:var(--text-muted); text-align:right; position:sticky; top:calc(var(--trs-header-h, 0px) - 1px); z-index:1; background:var(--gray-50); box-shadow:inset 0 -2px 0 var(--border-color);">${__(
 						"Declared Amount"
 					)}</th>
 				</tr>

--- a/india_payroll/public/js/tax_regime_selector/templates.js
+++ b/india_payroll/public/js/tax_regime_selector/templates.js
@@ -60,8 +60,8 @@ export function mainLayout(hasHra) {
 	return `
 		<div style="display:flex; gap:15px; align-items:flex-start;">
 			<div style="flex:0 0 65%; max-width:65%; min-width:0;">
-				<div class="frappe-card" style="padding: 16px; max-height:calc(80vh + 1rem); display:flex; flex-direction:column;">
-					<div style="display:flex; justify-content:space-between; align-items:center; gap:12px; flex-shrink:0; margin-bottom:16px;">
+				<div class="frappe-card" style="padding: 0; max-height:calc(80vh + 1rem); overflow-y:auto; overflow-x:hidden;">
+					<div style="display:flex; justify-content:space-between; align-items:start; gap:12px; padding:16px 16px 26px; position:sticky; top:0; z-index:3; background:var(--card-bg);">
 						<span style="font-size:var(--text-lg); font-weight:600;">${__(
 							"Add your exemptions to compare tax in both regimes"
 						)}</span>
@@ -69,7 +69,7 @@ export function mainLayout(hasHra) {
 							${__("Declare Tax Exemptions →")}
 						</button>
 					</div>
-					<div style="overflow-y:auto; overflow-x:hidden; flex:1; min-height:0;">
+					<div style="margin:0 16px 16px;">
 						${
 							hasHra
 								? `


### PR DESCRIPTION

https://github.com/user-attachments/assets/abe21657-c75b-4652-95ac-95522c78227b

<br>
<img width="577" height="273" alt="image" src="https://github.com/user-attachments/assets/d06b58cd-e33a-45a4-ae15-287a0e2c3577" />
<br>
<img width="577" height="439" alt="image" src="https://github.com/user-attachments/assets/3ed79547-495e-43c5-b091-8644d4be3207" />
<br>

https://github.com/user-attachments/assets/f8511a98-7ea9-471b-8ac2-978b2b1938e3

<br>

<img width="133" height="321" alt="image" src="https://github.com/user-attachments/assets/284fb7a1-1e8e-470b-9f8c-8e4c6ceb8c80" />
<br>

Pill / selection logic (comparison.js):
- Save Regime now acts like the dirty indicator: gated on staged != saved, so it
  hides after a save and returns only when a different regime is picked.
- Selected vs Suggested on different cards: drop "Suggested" on submitted SSAs
  (can't switch), else show "Selected" blue + "Suggested" green.
- In a tie, "Selected" pill is blue (not green) to match the border and banner.
- Card border follows the pill color (blue for "Selected"/"Default", else green).

Scrollable card + sticky headers (templates.js, controller.js, declarations.js):
- Card itself scrolls (not the inner div); header row pinned via position: sticky.
- Measure header height -> --trs-header-h; offset the sticky thead by it so it
  stacks under the header instead of colliding at top:0.
- Drop card padding (16px + inner); inset children with 16px -> padding on the
  sticky header (bg covers the gap, no scroll bleed-through), margin on content.

Table header (declarations.js):
- Round the top corners.