### PR TITLE
fix(Tax Regime Selector): add module breadcrumb, changed "Selected" to "Saved"

### DIFF
--- a/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.js
+++ b/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.js
@@ -4,5 +4,7 @@
 frappe.pages["tax-regime-selector"].on_page_load = function (wrapper) {
 	frappe.require(["tax_regime_selector.bundle.js", "tax_regime_selector.bundle.css"], () => {
 		new window.india_payroll.ui.TaxRegimeSelector(wrapper);
+		frappe.breadcrumbs.add("India Payroll");
+		frappe.breadcrumbs.append_breadcrumb_element("", __("Tax Regime Selector"));
 	});
 };

--- a/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.js
+++ b/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.js
@@ -5,6 +5,5 @@ frappe.pages["tax-regime-selector"].on_page_load = function (wrapper) {
 	frappe.require(["tax_regime_selector.bundle.js", "tax_regime_selector.bundle.css"], () => {
 		new window.india_payroll.ui.TaxRegimeSelector(wrapper);
 		frappe.breadcrumbs.add("India Payroll");
-		frappe.breadcrumbs.append_breadcrumb_element("", __("Tax Regime Selector"));
 	});
 };

--- a/india_payroll/public/js/tax_regime_selector/comparison.js
+++ b/india_payroll/public/js/tax_regime_selector/comparison.js
@@ -15,7 +15,7 @@ export function renderComparison(ctrl, result) {
 
 	// A regime choice rendered as a radio card. Picking it stages the choice; the
 	// staged card gets a colored border (green, or blue on a tie). Label precedence
-	// is Selected > Suggested/Default. The regime in force is the saved choice (when
+	// is Saved > Suggested/Default. The regime in force is the saved choice (when
 	// it still matches a current card), or - on a submitted/locked SSA with nothing
 	// valid saved - New Regime as the system default.
 	const regime_card = (label, regime, is_winner, tie_pill) => {
@@ -38,7 +38,7 @@ export function renderComparison(ctrl, result) {
 		let pill_color = "";
 		let pill_label = "";
 		if (is_selected) {
-			pill_label = __("Selected");
+			pill_label = __("Saved");
 			// Blue (neutral) in a tie - neither regime is cheaper, so green would falsely
 			// claim "optimal" - or on an editable SSA where the recommendation differs (a
 			// distinct green "Suggested" sits alongside). Otherwise the lone choice is green.
@@ -65,7 +65,7 @@ export function renderComparison(ctrl, result) {
 
 		// In draft the staged radio drives the border; on a submitted SSA there is no
 		// staging, so the in-force (selected) card carries the highlight instead. The
-		// highlight follows the pill color so the blue "Selected" card gets a blue border.
+		// highlight follows the pill color so the blue "Saved" card gets a blue border.
 		const is_highlighted = is_staged || (ctrl.is_submitted && is_selected);
 		const border = is_highlighted
 			? pill_color === "blue" || is_tie
@@ -141,10 +141,10 @@ export function renderComparison(ctrl, result) {
 			${regime_card(__("Old Regime"), old, !is_tie && old_wins, false)}
 			${regime_card(__("New Regime"), new_, !is_tie && !old_wins, true)}
 		</div>
-		<div class="form-message ${alert_color}" style="margin-bottom:15px; font-weight:normal; margin-right:15px; flex-shrink:0; border-radius:var(--border-radius);">
+		<div class="form-message ${alert_color}" style="margin-bottom:15px; font-weight:normal; margin-right:15px; flex-shrink:0; border-radius:8px;">
 			${winner_label}
 		</div>
-		<div style="display:flex; flex-direction:column; border:1px solid var(--border-color); border-radius:var(--border-radius); overflow:hidden; font-size:var(--text-sm); margin-right:15px; flex:1; min-height:0;">
+		<div style="display:flex; flex-direction:column; border:1px solid var(--border-color); border-radius:8px; overflow:hidden; font-size:var(--text-sm); margin-right:15px; flex:1; min-height:0;">
 			<table style="width:100%; border-collapse:collapse; table-layout:fixed; flex-shrink:0;">
 				${colgroup}
 				<thead>${thead}</thead>

--- a/india_payroll/public/js/tax_regime_selector/controller.js
+++ b/india_payroll/public/js/tax_regime_selector/controller.js
@@ -49,10 +49,11 @@ export class TaxRegimeSelector {
 				label: __("Employee"),
 				placeholder: __("Select Employee"),
 				reqd: 1,
-				change: () => {
+				onchange: () => {
 					const employee = this.employee_control.get_value();
-					if (employee && employee !== this._current_employee) {
-						this._current_employee = employee;
+					if (employee === this._current_employee) return;
+					this._current_employee = employee;
+					if (employee) {
 						this.load_employee(employee);
 					} else {
 						this.annual_gross_control.set_value("");
@@ -71,7 +72,7 @@ export class TaxRegimeSelector {
 				fieldname: "annual_gross_earning",
 				label: __("Annual Gross Earning"),
 				reqd: 1,
-				change: () => {
+				onchange: () => {
 					const val = flt(this.annual_gross_control.get_value());
 					if (val > 0) {
 						this.annual_gross = val;

--- a/india_payroll/public/js/tax_regime_selector/controller.js
+++ b/india_payroll/public/js/tax_regime_selector/controller.js
@@ -51,7 +51,8 @@ export class TaxRegimeSelector {
 				reqd: 1,
 				change: () => {
 					const employee = this.employee_control.get_value();
-					if (employee) {
+					if (employee && employee !== this._current_employee) {
+						this._current_employee = employee;
 						this.load_employee(employee);
 					} else {
 						this.annual_gross_control.set_value("");

--- a/india_payroll/public/js/tax_regime_selector/declarations.js
+++ b/india_payroll/public/js/tax_regime_selector/declarations.js
@@ -75,8 +75,6 @@ export function setupDeclarationTable(ctrl) {
 		<style>
 			.declaration-input::-webkit-outer-spin-button,
 			.declaration-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-			.declaration-table thead th:first-child { border-top-left-radius: var(--border-radius); }
-			.declaration-table thead th:last-child { border-top-right-radius: var(--border-radius); }
 		</style>
 		<table style="width:100%; table-layout:fixed; border-collapse:collapse;" class="declaration-table">
 			<colgroup>

--- a/india_payroll/public/js/tax_regime_selector/templates.js
+++ b/india_payroll/public/js/tax_regime_selector/templates.js
@@ -95,7 +95,7 @@ export function mainLayout(hasHra) {
 								<button class="btn btn-xs btn-default" id="collapse-all-btn">${__("Collapse All")}</button>
 							</div>
 						</div>
-						<div id="declaration-table-wrapper"></div>
+						<div id="declaration-table-wrapper" style="border-radius:8px 8px 0 0; overflow:clip;"></div>
 						<div id="declaration-empty" class="text-muted text-center" style="display:none; padding:20px;">
 							${__("No deductions found")}
 						</div>


### PR DESCRIPTION
Added whole breadcrumb instead of just module name
<img width="635" height="183" alt="image" src="https://github.com/user-attachments/assets/811c7ed0-220c-494c-847b-faac4bed4f71" />

Changed "Selected" to "Saved"
<img width="577" height="198" alt="image" src="https://github.com/user-attachments/assets/7e93f5a3-f069-4813-ab4a-e77922144b63" />

Fixed vanishing frappe.throw