### PR TITLE
fix: use indiacator pill for styling status fields

### DIFF
--- a/india_payroll/india_payroll/report/esic_register/esic_register.js
+++ b/india_payroll/india_payroll/report/esic_register/esic_register.js
@@ -66,10 +66,9 @@ frappe.query_reports["ESIC Register"] = {
 	formatter(value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);
 		if (column.fieldname === "coverage_status" && data) {
-			const colours = { Covered: "#2d8a2d", PwD: "#1a5fa8", Exempt: "#888" };
+			const colours = { Covered: "green", PwD: "blue", Exempt: "grey" };
 			const bg = colours[data.coverage_status] || "#888";
-			value = `<span style="background:${bg};color:#fff;border-radius:10px;
-				padding:1px 10px;font-size:0.8em;white-space:nowrap;">${data.coverage_status}</span>`;
+			value = `<span class="indicator-pill ${bg}">${data.coverage_status}</span>`;
 		}
 		return value;
 	},

--- a/india_payroll/india_payroll/report/esic_register/esic_register.js
+++ b/india_payroll/india_payroll/report/esic_register/esic_register.js
@@ -67,7 +67,7 @@ frappe.query_reports["ESIC Register"] = {
 		value = default_formatter(value, row, column, data);
 		if (column.fieldname === "coverage_status" && data) {
 			const colours = { Covered: "green", PwD: "blue", Exempt: "grey" };
-			const bg = colours[data.coverage_status] || "#888";
+			const bg = colours[data.coverage_status] || "grey";
 			value = `<span class="indicator-pill ${bg}">${data.coverage_status}</span>`;
 		}
 		return value;

--- a/india_payroll/india_payroll/report/lwf_register/lwf_register.js
+++ b/india_payroll/india_payroll/report/lwf_register/lwf_register.js
@@ -87,14 +87,13 @@ frappe.query_reports["LWF Register"] = {
 		value = default_formatter(value, row, column, data);
 		if (column.fieldname === "deduction_status" && data) {
 			const colours = {
-				Deducted: "#2d8a2d",
-				"Non-Deduction Month": "#888",
-				Exempted: "#1a5fa8",
-				"No LWF State": "#aaa",
+				Deducted: "green",
+				"Non-Deduction Month": "darkgrey",
+				Exempted: "blue",
+				"No LWF State": "grey",
 			};
 			const bg = colours[data.deduction_status] || "#888";
-			value = `<span style="background:${bg};color:#fff;border-radius:10px;
-				padding:1px 10px;font-size:0.8em;white-space:nowrap;">${data.deduction_status}</span>`;
+			value = `<span class="indicator-pill ${bg}">${data.deduction_status}</span>`;
 		}
 		if (column.fieldname === "frequency" && data && data.frequency) {
 			value = `<span style="font-size:0.85em;color:#555;">${data.frequency}</span>`;

--- a/india_payroll/india_payroll/report/lwf_register/lwf_register.js
+++ b/india_payroll/india_payroll/report/lwf_register/lwf_register.js
@@ -92,7 +92,7 @@ frappe.query_reports["LWF Register"] = {
 				Exempted: "blue",
 				"No LWF State": "grey",
 			};
-			const bg = colours[data.deduction_status] || "#888";
+			const bg = colours[data.deduction_status] || "grey";
 			value = `<span class="indicator-pill ${bg}">${data.deduction_status}</span>`;
 		}
 		if (column.fieldname === "frequency" && data && data.frequency) {


### PR DESCRIPTION
Using the existing styling elements to things consistent

### Before 
<img width="1024" height="617" alt="image" src="https://github.com/user-attachments/assets/253a19af-e01d-4e02-b6d5-af8d535cacf2" />

### After
<img width="1658" height="715" alt="image" src="https://github.com/user-attachments/assets/4213f36d-75ee-468f-ac92-d8017093b368" />

