### PR TITLE
fix: add separate employer contribution component for ESI

### DIFF
--- a/india_payroll/hooks.py
+++ b/india_payroll/hooks.py
@@ -272,6 +272,7 @@ regional_overrides = {
 	"India": {
 		"hrms.payroll.doctype.income_tax_slab.income_tax_slab.apply_surcharge_with_marginal_relief": "india_payroll.india_payroll.income_tax_utils.apply_surcharge_with_marginal_relief",
 		"hrms.payroll.doctype.salary_slip.salary_slip.apply_regional_deductions": "india_payroll.india_payroll.salary_slip.apply_regional_deductions",
+		"hrms.payroll.doctype.salary_structure_assignment.salary_structure_assignment.apply_regional_ctc_components": "india_payroll.india_payroll.employer_contributions.apply_regional_ctc_components",
 	}
 }
 

--- a/india_payroll/india_payroll/employer_contributions.py
+++ b/india_payroll/india_payroll/employer_contributions.py
@@ -17,7 +17,7 @@ CONTRIBUTION_SOURCES = (esi.get_employer_contributions,)
 CONFIG_FIELDS = ("is_person_with_disability",)
 
 
-def compute_employer_contributions(earnings, config, *, paid_field="amount") -> dict:
+def compute_employer_contributions(earnings, config, *, paid_field="amount", company=None) -> dict:
 	"""Every employer contribution for these earnings, keyed by component.
 
 	Eligibility always reads ``default_amount``. The paid wage differs by
@@ -25,7 +25,7 @@ def compute_employer_contributions(earnings, config, *, paid_field="amount") -> 
 	"""
 	amounts = {}
 	for get_contributions in CONTRIBUTION_SOURCES:
-		amounts.update(get_contributions(earnings, config, paid_field=paid_field))
+		amounts.update(get_contributions(earnings, config, paid_field=paid_field, company=company))
 	return amounts
 
 
@@ -33,7 +33,9 @@ def apply_regional_ctc_components(assignment, rows_by_type, data) -> None:
 	"""Regional CTC hook -- without it, CTC understates the employer's cost."""
 	earnings = rows_by_type.get("earnings") or []
 	# an assignment evaluates a full cycle, so full-cycle wage is the paid wage
-	contributions = compute_employer_contributions(earnings, assignment, paid_field="default_amount")
+	contributions = compute_employer_contributions(
+		earnings, assignment, paid_field="default_amount", company=assignment.company
+	)
 
 	for component, amount in contributions.items():
 		assignment.upsert_employer_contribution(rows_by_type, data, component, amount)
@@ -48,7 +50,7 @@ def set_slip_employer_contributions(doc) -> None:
 		return
 
 	config = get_slip_ssa_values(doc, list(CONFIG_FIELDS))
-	amounts = compute_employer_contributions(doc.earnings, config)
+	amounts = compute_employer_contributions(doc.earnings, config, company=doc.company)
 
 	for component, amount in amounts.items():
 		doc.employer_contributions = [

--- a/india_payroll/india_payroll/employer_contributions.py
+++ b/india_payroll/india_payroll/employer_contributions.py
@@ -1,0 +1,58 @@
+"""Statutory employer contributions, for both the salary slip and CTC.
+
+Each statute exposes ``get_employer_contributions()`` returning
+``{salary_component: amount}``. Adding one means a function and a registry
+entry; neither hook below changes.
+"""
+
+import frappe
+from frappe.utils import flt
+
+from india_payroll.india_payroll import esi
+from india_payroll.india_payroll.utils import get_slip_ssa_values
+
+CONTRIBUTION_SOURCES = (esi.get_employer_contributions,)
+
+# assignment fields the sources read
+CONFIG_FIELDS = ("is_person_with_disability",)
+
+
+def compute_employer_contributions(earnings, config, *, paid_field="amount") -> dict:
+	"""Every employer contribution for these earnings, keyed by component.
+
+	Eligibility always reads ``default_amount``. The paid wage differs by
+	context, so the caller names the field.
+	"""
+	amounts = {}
+	for get_contributions in CONTRIBUTION_SOURCES:
+		amounts.update(get_contributions(earnings, config, paid_field=paid_field))
+	return amounts
+
+
+def apply_regional_ctc_components(assignment, rows_by_type, data) -> None:
+	"""Regional CTC hook -- without it, CTC understates the employer's cost."""
+	earnings = rows_by_type.get("earnings") or []
+	# an assignment evaluates a full cycle, so full-cycle wage is the paid wage
+	contributions = compute_employer_contributions(earnings, assignment, paid_field="default_amount")
+
+	for component, amount in contributions.items():
+		assignment.upsert_employer_contribution(rows_by_type, data, component, amount)
+
+
+def set_slip_employer_contributions(doc) -> None:
+	"""Write the employer's statutory cost onto the salary slip.
+
+	Informational only -- never affects gross, deduction or net pay.
+	"""
+	if not doc.salary_structure:
+		return
+
+	config = get_slip_ssa_values(doc, list(CONFIG_FIELDS))
+	amounts = compute_employer_contributions(doc.earnings, config)
+
+	for component, amount in amounts.items():
+		doc.employer_contributions = [
+			row for row in doc.employer_contributions if row.salary_component != component
+		]
+		if flt(amount) > 0 and frappe.db.exists("Salary Component", component):
+			doc.append("employer_contributions", {"salary_component": component, "amount": amount})

--- a/india_payroll/india_payroll/esi.py
+++ b/india_payroll/india_payroll/esi.py
@@ -5,21 +5,51 @@ from india_payroll.india_payroll.company_settings import is_statutory_enabled
 from india_payroll.india_payroll.utils import get_slip_ssa_values
 
 ESI_EMPLOYEE_COMPONENT = "Employee State Insurance"
+ESI_EMPLOYER_COMPONENT = "Employer State Insurance"
 
-# Combined ESI contribution rate deducted on the salary slip:
-# employee share (0.75%) + employer share (3.25%) = 4%
-ESI_RATE = 0.04
+EMPLOYEE_ESI_RATE = 0.0075
+EMPLOYER_ESI_RATE = 0.0325
 
 ESI_WAGE_CEILING = 21_000
 ESI_WAGE_CEILING_DISABILITY = 25_000
 
 
+def get_esi_split(gross, *, is_person_with_disability=False, ceiling_gross=None) -> frappe._dict:
+	"""
+	Split the ESI contribution on ``gross`` into the employee and employer shares.
+
+	``ceiling_gross`` decides coverage when it differs from the wage the
+	contribution is levied on — the salary slip judges coverage on the full
+	monthly gross but contributes on the LOP-prorated wage. Callers with a
+	single wage (the CTC hook, the register) omit it.
+	"""
+	gross = flt(gross)
+	ceiling = ESI_WAGE_CEILING_DISABILITY if is_person_with_disability else ESI_WAGE_CEILING
+	covered = flt(ceiling_gross if ceiling_gross is not None else gross) <= ceiling
+
+	if not covered or gross <= 0:
+		return frappe._dict(covered=False, ceiling=ceiling, employee=0.0, employer=0.0, total=0.0)
+
+	employee = flt(gross * EMPLOYEE_ESI_RATE, 2)
+	employer = flt(gross * EMPLOYER_ESI_RATE, 2)
+
+	return frappe._dict(
+		covered=True,
+		ceiling=ceiling,
+		employee=employee,
+		employer=employer,
+		total=flt(employee + employer, 2),
+	)
+
+
 def apply_esi(doc, method=None) -> None:
 	"""
-	Salary Slip regional deduction hook (see apply_regional_deductions).
+	Salary Slip regional hook (see apply_regional_deductions).
 
-	Injects ESI contributions when the employee's wage is within the prescribed
-	ceiling; otherwise removes any previously injected ESI rows.
+	Injects the employee's ESI share (0.75%) as a deduction and the employer's
+	share (3.25%) as an employer contribution, when the employee's wage is
+	within the prescribed ceiling; otherwise removes any previously injected
+	ESI rows.
 
 	Coverage (the wage-ceiling test) is decided on the *full* monthly gross from
 	the structure assignment — not the payment-days-prorated ``doc.gross_pay`` —
@@ -33,29 +63,44 @@ def apply_esi(doc, method=None) -> None:
 	if not doc.salary_structure:
 		return
 
-	if not frappe.db.exists("Salary Component", ESI_EMPLOYEE_COMPONENT):
-		frappe.msgprint(
-			frappe._(
-				"Salary Component <b>{0}</b> not found. "
-				"Please reinstall the India Payroll app or create it manually."
-			).format(ESI_EMPLOYEE_COMPONENT),
-			indicator="orange",
-			alert=True,
-		)
+	if not _required_components_exist():
 		return
 
 	# Determine the applicable wage ceiling (PwD flag lives on the assignment)
 	is_disabled = get_slip_ssa_values(doc, ["is_person_with_disability"]).get("is_person_with_disability")
-	wage_ceiling = ESI_WAGE_CEILING_DISABILITY if is_disabled else ESI_WAGE_CEILING
 
-	if _full_gross(doc) > wage_ceiling:
+	split = get_esi_split(
+		doc.gross_pay,
+		is_person_with_disability=bool(is_disabled),
+		ceiling_gross=_full_gross(doc),
+	)
+
+	if not split.covered:
 		# Wage above the ceiling — not covered. Strip any stale ESI rows.
 		_remove_esi_components(doc)
 		return
 
-	esi = flt(flt(doc.gross_pay) * ESI_RATE, 2)
+	_update_esi_in_salary_slip(doc, split)
 
-	_update_esi_in_salary_slip(doc, esi)
+
+def _required_components_exist() -> bool:
+	missing = [
+		component
+		for component in (ESI_EMPLOYEE_COMPONENT, ESI_EMPLOYER_COMPONENT)
+		if not frappe.db.exists("Salary Component", component)
+	]
+	if not missing:
+		return True
+
+	frappe.msgprint(
+		frappe._(
+			"Salary Component <b>{0}</b> not found. "
+			"Please reinstall the India Payroll app or create it manually."
+		).format(", ".join(missing)),
+		indicator="orange",
+		alert=True,
+	)
+	return False
 
 
 def _full_gross(doc) -> float:
@@ -66,26 +111,28 @@ def _full_gross(doc) -> float:
 
 
 def _remove_esi_components(doc) -> None:
-	"""Remove the ESI employee component from the salary slip deductions."""
+	"""Remove both ESI rows from the salary slip."""
 	doc.deductions = [d for d in doc.deductions if d.salary_component != ESI_EMPLOYEE_COMPONENT]
+	doc.employer_contributions = [
+		d for d in doc.employer_contributions if d.salary_component != ESI_EMPLOYER_COMPONENT
+	]
 
 
-def _update_esi_in_salary_slip(doc, esi: float) -> None:
+def _update_esi_in_salary_slip(doc, split) -> None:
 	"""
-	Replace any existing Employee ESI row with the freshly computed amount.
+	Replace any existing ESI rows with the freshly computed shares.
 
-	The single row covers the full 4% ESI contribution (employee 0.75% +
-	employer 3.25%).  The employer's share is part of the CTC and is not
-	shown as a separate component.
+	The employee's 0.75% reduces net pay; the employer's 3.25% is a cost the
+	employer bears on top of gross and is shown on the slip for transparency
+	without affecting gross, total deduction or net pay.
 	"""
-	# Remove stale row first
-	doc.deductions = [d for d in doc.deductions if d.salary_component != ESI_EMPLOYEE_COMPONENT]
+	_remove_esi_components(doc)
 
-	if esi > 0:
+	if split.employee > 0:
+		doc.append("deductions", {"salary_component": ESI_EMPLOYEE_COMPONENT, "amount": split.employee})
+
+	if split.employer > 0:
 		doc.append(
-			"deductions",
-			{
-				"salary_component": ESI_EMPLOYEE_COMPONENT,
-				"amount": esi,
-			},
+			"employer_contributions",
+			{"salary_component": ESI_EMPLOYER_COMPONENT, "amount": split.employer},
 		)

--- a/india_payroll/india_payroll/esi.py
+++ b/india_payroll/india_payroll/esi.py
@@ -15,13 +15,10 @@ ESI_WAGE_CEILING_DISABILITY = 25_000
 
 
 def get_esi_split(gross, *, is_person_with_disability=False, ceiling_gross=None) -> frappe._dict:
-	"""
-	Split the ESI contribution on ``gross`` into the employee and employer shares.
+	"""Split ESI on ``gross`` into the employee and employer shares.
 
-	``ceiling_gross`` decides coverage when it differs from the wage the
-	contribution is levied on — the salary slip judges coverage on the full
-	monthly gross but contributes on the LOP-prorated wage. Callers with a
-	single wage (the CTC hook, the register) omit it.
+	``ceiling_gross`` decides coverage when it differs from the wage levied on -
+	the slip judges coverage on full gross but contributes on the paid wage.
 	"""
 	gross = flt(gross)
 	ceiling = ESI_WAGE_CEILING_DISABILITY if is_person_with_disability else ESI_WAGE_CEILING
@@ -43,18 +40,11 @@ def get_esi_split(gross, *, is_person_with_disability=False, ceiling_gross=None)
 
 
 def apply_esi(doc, method=None) -> None:
-	"""
-	Salary Slip regional hook (see apply_regional_deductions).
+	"""Deduct the employee's 0.75% ESI share.
 
-	Injects the employee's ESI share (0.75%) as a deduction and the employer's
-	share (3.25%) as an employer contribution, when the employee's wage is
-	within the prescribed ceiling; otherwise removes any previously injected
-	ESI rows.
-
-	Coverage (the wage-ceiling test) is decided on the *full* monthly gross from
-	the structure assignment — not the payment-days-prorated ``doc.gross_pay`` —
-	so a high earner is not wrongly pulled into ESI in an LOP month. The
-	contribution itself is still levied on the actual wages paid (``gross_pay``).
+	Coverage is judged on full gross so LOP cannot pull a high earner into ESI,
+	while the contribution follows the wage actually paid. The employer's 3.25%
+	is written by ``employer_contributions``.
 	"""
 	if not is_statutory_enabled("esic", doc.company):
 		_remove_esi_components(doc)
@@ -66,17 +56,16 @@ def apply_esi(doc, method=None) -> None:
 	if not _required_components_exist():
 		return
 
-	# Determine the applicable wage ceiling (PwD flag lives on the assignment)
+	# the PwD flag decides which ceiling applies
 	is_disabled = get_slip_ssa_values(doc, ["is_person_with_disability"]).get("is_person_with_disability")
 
 	split = get_esi_split(
 		doc.gross_pay,
 		is_person_with_disability=bool(is_disabled),
-		ceiling_gross=_full_gross(doc),
+		ceiling_gross=esi_gross(doc.earnings, "default_amount"),
 	)
 
 	if not split.covered:
-		# Wage above the ceiling — not covered. Strip any stale ESI rows.
 		_remove_esi_components(doc)
 		return
 
@@ -103,36 +92,42 @@ def _required_components_exist() -> bool:
 	return False
 
 
-def _full_gross(doc) -> float:
-	"""Full, unprorated gross for the period — the gross the structure assignment
-	yields with no LOP.
+def esi_gross(earnings, field="amount") -> float:
+	"""ESI is levied on gross wages: every payable earning.
+
+	``amount`` is the wage paid, ``default_amount`` the full cycle with no LOP.
 	"""
-	return sum(flt(e.default_amount) for e in doc.earnings if not e.do_not_include_in_total)
+	return sum(
+		flt(row.get(field))
+		for row in earnings
+		if not row.get("statistical_component") and not row.get("do_not_include_in_total")
+	)
 
 
 def _remove_esi_components(doc) -> None:
-	"""Remove both ESI rows from the salary slip."""
+	"""Remove the employee ESI row from the salary slip."""
 	doc.deductions = [d for d in doc.deductions if d.salary_component != ESI_EMPLOYEE_COMPONENT]
-	doc.employer_contributions = [
-		d for d in doc.employer_contributions if d.salary_component != ESI_EMPLOYER_COMPONENT
-	]
 
 
 def _update_esi_in_salary_slip(doc, split) -> None:
-	"""
-	Replace any existing ESI rows with the freshly computed shares.
-
-	The employee's 0.75% reduces net pay; the employer's 3.25% is a cost the
-	employer bears on top of gross and is shown on the slip for transparency
-	without affecting gross, total deduction or net pay.
-	"""
+	"""Replace any existing employee ESI row with the freshly computed share."""
 	_remove_esi_components(doc)
 
 	if split.employee > 0:
 		doc.append("deductions", {"salary_component": ESI_EMPLOYEE_COMPONENT, "amount": split.employee})
 
-	if split.employer > 0:
-		doc.append(
-			"employer_contributions",
-			{"salary_component": ESI_EMPLOYER_COMPONENT, "amount": split.employer},
-		)
+
+def get_employer_contributions(earnings, config, *, paid_field="amount") -> dict:
+	"""Employer ESI, keyed by component.
+
+	Returns zero rather than omitting it, so a stale row gets cleared.
+	"""
+	if not frappe.db.get_single_value("Payroll Settings", "enable_esic"):
+		return {ESI_EMPLOYER_COMPONENT: 0.0}
+
+	split = get_esi_split(
+		esi_gross(earnings, paid_field),
+		is_person_with_disability=bool(config.get("is_person_with_disability")),
+		ceiling_gross=esi_gross(earnings, "default_amount"),
+	)
+	return {ESI_EMPLOYER_COMPONENT: split.employer}

--- a/india_payroll/india_payroll/esi.py
+++ b/india_payroll/india_payroll/esi.py
@@ -117,12 +117,12 @@ def _update_esi_in_salary_slip(doc, split) -> None:
 		doc.append("deductions", {"salary_component": ESI_EMPLOYEE_COMPONENT, "amount": split.employee})
 
 
-def get_employer_contributions(earnings, config, *, paid_field="amount") -> dict:
+def get_employer_contributions(earnings, config, *, paid_field="amount", company=None) -> dict:
 	"""Employer ESI, keyed by component.
 
 	Returns zero rather than omitting it, so a stale row gets cleared.
 	"""
-	if not frappe.db.get_single_value("Payroll Settings", "enable_esic"):
+	if not is_statutory_enabled("esic", company):
 		return {ESI_EMPLOYER_COMPONENT: 0.0}
 
 	split = get_esi_split(

--- a/india_payroll/india_payroll/esi.py
+++ b/india_payroll/india_payroll/esi.py
@@ -53,7 +53,7 @@ def apply_esi(doc, method=None) -> None:
 	if not doc.salary_structure:
 		return
 
-	if not _required_components_exist():
+	if not _employee_component_exists():
 		return
 
 	# the PwD flag decides which ceiling applies
@@ -72,20 +72,17 @@ def apply_esi(doc, method=None) -> None:
 	_update_esi_in_salary_slip(doc, split)
 
 
-def _required_components_exist() -> bool:
-	missing = [
-		component
-		for component in (ESI_EMPLOYEE_COMPONENT, ESI_EMPLOYER_COMPONENT)
-		if not frappe.db.exists("Salary Component", component)
-	]
-	if not missing:
+def _employee_component_exists() -> bool:
+	"""Only the employee component gates the deduction. The employer component is
+	written elsewhere, so a missing one must not stop the employee's share."""
+	if frappe.db.exists("Salary Component", ESI_EMPLOYEE_COMPONENT):
 		return True
 
 	frappe.msgprint(
 		frappe._(
 			"Salary Component <b>{0}</b> not found. "
 			"Please reinstall the India Payroll app or create it manually."
-		).format(", ".join(missing)),
+		).format(ESI_EMPLOYEE_COMPONENT),
 		indicator="orange",
 		alert=True,
 	)

--- a/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.py
+++ b/india_payroll/india_payroll/page/tax_regime_selector/tax_regime_selector.py
@@ -41,9 +41,83 @@ SECTION_CAPS = {
 }
 
 
+def validate_tax_master_access() -> None:
+	"""Both setup paths insert with ignore_permissions, so confirm the caller may
+	create the records they create."""
+	if frappe.has_permission("Income Tax Slab", "create") and frappe.has_permission(
+		"Employee Tax Exemption Category", "create"
+	):
+		return
+
+	frappe.throw(
+		frappe._(
+			"Income Tax Slab and Employee Tax Exemption Category are not set up. Ask an HR Manager to open the Tax Regime Selector once to create them."
+		),
+		frappe.PermissionError,
+		title=frappe._("Not Permitted"),
+	)
+
+
+def validate_employee_access(employee: str, ptype: str = "read") -> None:
+	"""Allow an employee to act on their own tax regime. Any other caller needs
+	`ptype` permission on that employee's Salary Structure Assignment."""
+	if not employee:
+		frappe.throw(frappe._("Employee is required"))
+
+	if not frappe.db.exists("Employee", employee):
+		frappe.throw(frappe._("Employee {0} not found").format(employee), frappe.DoesNotExistError)
+
+	if frappe.session.user == frappe.db.get_value("Employee", employee, "user_id"):
+		return
+
+	frappe.has_permission("Employee", "read", doc=employee, throw=True)
+
+	assignment = get_latest_assignment(employee)
+	frappe.has_permission(
+		"Salary Structure Assignment",
+		ptype,
+		doc=assignment.name if assignment else None,
+		throw=True,
+	)
+
+
+def validate_income_tax_slab(assignment: str, income_tax_slab: str) -> None:
+	"""Repeat the Salary Structure Assignment's own slab checks, since writing the
+	field directly skips them."""
+	if not income_tax_slab:
+		frappe.throw(frappe._("Income Tax Slab is required"))
+
+	slab = frappe.db.get_value(
+		"Income Tax Slab",
+		income_tax_slab,
+		["docstatus", "disabled", "currency", "company"],
+		as_dict=True,
+	)
+	if not slab:
+		frappe.throw(frappe._("Income Tax Slab {0} not found").format(income_tax_slab))
+	if slab.docstatus != 1:
+		frappe.throw(frappe._("Income Tax Slab {0} is not submitted").format(income_tax_slab))
+	if slab.disabled:
+		frappe.throw(frappe._("Income Tax Slab {0} is disabled").format(income_tax_slab))
+
+	ssa = frappe.db.get_value(
+		"Salary Structure Assignment", assignment, ["company", "currency"], as_dict=True
+	)
+	if slab.company and slab.company != ssa.company:
+		frappe.throw(
+			frappe._("Income Tax Slab {0} belongs to company {1}").format(income_tax_slab, slab.company)
+		)
+	if slab.currency != ssa.currency:
+		frappe.throw(
+			frappe._("Currency of Income Tax Slab {0} should be {1}").format(income_tax_slab, ssa.currency)
+		)
+
+
 @frappe.whitelist()
 def setup_if_missing() -> dict:
 	"""Idempotently create income tax slabs and exemption categories."""
+	validate_tax_master_access()
+
 	from india_payroll.install import create_income_tax_slabs
 
 	create_income_tax_slabs()
@@ -55,6 +129,8 @@ def setup_if_missing() -> dict:
 
 @frappe.whitelist()
 def get_employee_details(employee: str) -> dict:
+	validate_employee_access(employee)
+
 	data = get_employee_salary_data(employee)
 
 	categories = frappe.get_all(
@@ -62,6 +138,7 @@ def get_employee_details(employee: str) -> dict:
 		fields=["name", "max_amount", "description"],
 	)
 	if not categories:
+		validate_tax_master_access()
 		setup_tax_exemption_categories()
 		categories = frappe.get_all(
 			"Employee Tax Exemption Category",
@@ -155,6 +232,8 @@ def compute_tax_comparison(
 	city_type: str = "non-metro",
 	annual_gross: float = 0,
 ) -> dict:
+	validate_employee_access(employee)
+
 	if isinstance(declarations, str):
 		declarations = frappe.parse_json(declarations)
 
@@ -193,11 +272,9 @@ def compute_tax_comparison(
 
 
 def get_latest_assignment(employee):
-	"""Latest Salary Structure Assignment for the employee, regardless of docstatus
-	(draft or submitted). Returns the {name, docstatus} dict or None."""
 	return frappe.db.get_value(
 		"Salary Structure Assignment",
-		{"employee": employee},
+		{"employee": employee, "docstatus": ("<", 2)},
 		["name", "docstatus"],
 		order_by="from_date desc, creation desc",
 		as_dict=True,
@@ -206,19 +283,24 @@ def get_latest_assignment(employee):
 
 @frappe.whitelist()
 def set_tax_regime(employee: str, income_tax_slab: str) -> dict:
+	validate_employee_access(employee, "write")
+
 	assignment = get_latest_assignment(employee)
 	if not assignment:
 		frappe.throw(frappe._("No Salary Structure Assignment found for {0}").format(employee))
 	if assignment.docstatus == 1:
 		frappe.throw(frappe._("Salary Structure Assignment {0} is already submitted").format(assignment.name))
+
+	validate_income_tax_slab(assignment.name, income_tax_slab)
+
 	frappe.db.set_value("Salary Structure Assignment", assignment.name, "income_tax_slab", income_tax_slab)
 	return {"assignment": assignment.name}
 
 
 @frappe.whitelist()
 def notify_employee_to_select_tax_regime(assignment: str) -> dict:
-	"""Email the employee on this Salary Structure Assignment a prompt to pick
-	their tax regime in the Tax Regime Selector page."""
+	frappe.has_permission("Salary Structure Assignment", "email", throw=True)
+
 	ssa = frappe.db.get_value(
 		"Salary Structure Assignment",
 		assignment,
@@ -227,6 +309,8 @@ def notify_employee_to_select_tax_regime(assignment: str) -> dict:
 	)
 	if not ssa:
 		frappe.throw(frappe._("Salary Structure Assignment {0} not found").format(assignment))
+
+	frappe.has_permission("Salary Structure Assignment", "email", doc=assignment, throw=True)
 
 	emails = frappe.db.get_value(
 		"Employee",
@@ -261,6 +345,8 @@ def notify_employee_to_select_tax_regime(assignment: str) -> dict:
 def notify_employees_to_select_tax_regime(names: str | list[str]) -> dict:
 	"""Bulk version of notify_employee_to_select_tax_regime for the SSA list view.
 	Notifies only draft assignments; skips submitted ones and those without an email."""
+	frappe.has_permission("Salary Structure Assignment", "email", throw=True)
+
 	if isinstance(names, str):
 		names = frappe.parse_json(names)
 

--- a/india_payroll/india_payroll/page/tax_regime_selector/test_tax_regime_selector.py
+++ b/india_payroll/india_payroll/page/tax_regime_selector/test_tax_regime_selector.py
@@ -4,6 +4,7 @@
 import frappe
 from erpnext.setup.doctype.employee.test_employee import make_employee
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.permissions import add_user_permission, reset_perms, update_permission_property
 from hrms.payroll.doctype.salary_structure.test_salary_structure import (
 	create_salary_structure_assignment,
 	make_salary_structure,
@@ -17,7 +18,9 @@ from india_payroll.india_payroll.page.tax_regime_selector.tax_regime_selector im
 	compute_tax_comparison,
 	get_employee_details,
 	get_employee_salary_data,
+	notify_employee_to_select_tax_regime,
 	set_tax_regime,
+	setup_if_missing,
 )
 from india_payroll.india_payroll.tax_exemption_setup import setup_tax_exemption_categories
 from india_payroll.install import create_income_tax_slabs, get_custom_fields
@@ -86,11 +89,90 @@ def make_structure(employee, base, from_date="2026-04-01"):
 	return structure
 
 
+def make_draft_assignment(employee, base=100000, income_tax_slab=OLD_REGIME_SLAB):
+	"""Structure without an employee, then a draft assignment for that employee."""
+	ensure_salary_components()
+	make_salary_structure(
+		"IP Tax Regime Test Structure",
+		"Monthly",
+		company=COMPANY,
+		currency="INR",
+		earnings=EARNINGS,
+		deductions=DEDUCTIONS,
+	)
+	return frappe.get_doc(
+		{
+			"doctype": "Salary Structure Assignment",
+			"employee": employee,
+			"salary_structure": "IP Tax Regime Test Structure",
+			"from_date": "2026-04-01",
+			"base": base,
+			"company": COMPANY,
+			"currency": "INR",
+			"income_tax_slab": income_tax_slab,
+		}
+	).insert()
+
+
+def make_cancelled_assignment(employee, from_date):
+	ensure_salary_components()
+	make_salary_structure(
+		"IP Tax Regime Test Structure",
+		"Monthly",
+		company=COMPANY,
+		currency="INR",
+		earnings=EARNINGS,
+		deductions=DEDUCTIONS,
+	)
+	ssa = frappe.get_doc(
+		{
+			"doctype": "Salary Structure Assignment",
+			"employee": employee,
+			"salary_structure": "IP Tax Regime Test Structure",
+			"from_date": from_date,
+			"base": 100000,
+			"company": COMPANY,
+			"currency": "INR",
+			"income_tax_slab": OLD_REGIME_SLAB,
+		}
+	).insert()
+	ssa.submit()
+	ssa.cancel()
+	return ssa
+
+
+def ensure_self_user_permission(employee):
+	"""ERPNext adds this on Employee insert; assert it so a permission test that
+	depends on it fails loudly rather than silently passing."""
+	user = frappe.db.get_value("Employee", employee, "user_id")
+	if not frappe.db.exists("User Permission", {"allow": "Employee", "for_value": employee, "user": user}):
+		add_user_permission("Employee", employee, user, ignore_permissions=True)
+	return user
+
+
+def make_hr_user(email="ip_trs_hr@indiapayroll.com"):
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "IP TRS HR",
+				"send_welcome_email": 0,
+				"roles": [{"doctype": "Has Role", "role": "HR Manager"}],
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
 class TestTaxRegimeSelector(HRMSTestSuite):
 	def setUp(self):
+		frappe.set_user("Administrator")
 		create_custom_fields(get_custom_fields())
 		create_income_tax_slabs()
 		setup_tax_exemption_categories()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
 
 	def test_annual_gross_sourced_from_assignment(self):
 		"""get_employee_salary_data reads the SSA's computed annual_gross_earning."""
@@ -192,31 +274,155 @@ class TestTaxRegimeSelector(HRMSTestSuite):
 
 	def test_set_tax_regime_allowed_when_draft(self):
 		employee = make_employee("ip_trs_draft@indiapayroll.com", company=COMPANY)
-		ensure_salary_components()
-		# Structure only (no auto-assignment), then a DRAFT assignment.
-		make_salary_structure(
-			"IP Tax Regime Test Structure",
-			"Monthly",
-			company=COMPANY,
-			currency="INR",
-			earnings=EARNINGS,
-			deductions=DEDUCTIONS,
-		)
-		ssa = frappe.get_doc(
-			{
-				"doctype": "Salary Structure Assignment",
-				"employee": employee,
-				"salary_structure": "IP Tax Regime Test Structure",
-				"from_date": "2026-04-01",
-				"base": 100000,
-				"company": COMPANY,
-				"currency": "INR",
-				"income_tax_slab": OLD_REGIME_SLAB,
-			}
-		).insert()  # draft (docstatus 0)
+		ssa = make_draft_assignment(employee)
 
 		result = set_tax_regime(employee, NEW_REGIME_SLAB)
 		self.assertEqual(result["assignment"], ssa.name)
+		self.assertEqual(
+			frappe.db.get_value("Salary Structure Assignment", ssa.name, "income_tax_slab"),
+			NEW_REGIME_SLAB,
+		)
+
+	def test_cancelled_assignment_is_skipped(self):
+		"""A cancelled assignment can hold the latest from_date. get_latest_assignment
+		must skip it and return the draft instead of writing to a cancelled document."""
+		employee = make_employee("ip_trs_cancelled@indiapayroll.com", company=COMPANY)
+		draft = make_draft_assignment(employee)
+		cancelled = make_cancelled_assignment(employee, "2026-07-01")
+
+		result = set_tax_regime(employee, NEW_REGIME_SLAB)
+
+		self.assertEqual(result["assignment"], draft.name)
+		self.assertEqual(
+			frappe.db.get_value("Salary Structure Assignment", cancelled.name, "income_tax_slab"),
+			OLD_REGIME_SLAB,
+		)
+
+	def test_only_cancelled_assignment_reports_none_found(self):
+		employee = make_employee("ip_trs_only_cancelled@indiapayroll.com", company=COMPANY)
+		make_cancelled_assignment(employee, "2026-04-01")
+
+		self.assertRaises(frappe.ValidationError, set_tax_regime, employee, NEW_REGIME_SLAB)
+
+	def test_set_tax_regime_rejects_unknown_slab(self):
+		employee = make_employee("ip_trs_badslab@indiapayroll.com", company=COMPANY)
+		ssa = make_draft_assignment(employee)
+
+		self.assertRaises(frappe.ValidationError, set_tax_regime, employee, "Not A Real Slab")
+		self.assertEqual(
+			frappe.db.get_value("Salary Structure Assignment", ssa.name, "income_tax_slab"),
+			OLD_REGIME_SLAB,
+		)
+
+	def test_set_tax_regime_allowed_for_own_employee(self):
+		"""Self-service: the Employee role has no write permission on the assignment,
+		so the employee's own user must still be allowed through."""
+		employee = make_employee("ip_trs_self@indiapayroll.com", company=COMPANY)
+		ssa = make_draft_assignment(employee)
+		user = ensure_self_user_permission(employee)
+
+		frappe.set_user(user)
+		set_tax_regime(employee, NEW_REGIME_SLAB)
+
+		frappe.set_user("Administrator")
+		self.assertEqual(
+			frappe.db.get_value("Salary Structure Assignment", ssa.name, "income_tax_slab"),
+			NEW_REGIME_SLAB,
+		)
+
+	def test_set_tax_regime_blocked_for_other_employee(self):
+		attacker = make_employee("ip_trs_attacker@indiapayroll.com", company=COMPANY)
+		victim = make_employee("ip_trs_victim@indiapayroll.com", company=COMPANY)
+		make_draft_assignment(attacker)
+		victim_ssa = make_draft_assignment(victim)
+		attacker_user = ensure_self_user_permission(attacker)
+		ensure_self_user_permission(victim)
+
+		frappe.set_user(attacker_user)
+		self.assertRaises(frappe.PermissionError, set_tax_regime, victim, NEW_REGIME_SLAB)
+
+		frappe.set_user("Administrator")
+		self.assertEqual(
+			frappe.db.get_value("Salary Structure Assignment", victim_ssa.name, "income_tax_slab"),
+			OLD_REGIME_SLAB,
+		)
+
+	def test_read_endpoints_blocked_for_other_employee(self):
+		attacker = make_employee("ip_trs_reader@indiapayroll.com", company=COMPANY)
+		victim = make_employee("ip_trs_read_victim@indiapayroll.com", company=COMPANY)
+		make_draft_assignment(attacker)
+		make_draft_assignment(victim)
+		attacker_user = ensure_self_user_permission(attacker)
+		ensure_self_user_permission(victim)
+
+		frappe.set_user(attacker_user)
+		self.assertRaises(frappe.PermissionError, get_employee_details, victim)
+		self.assertRaises(frappe.PermissionError, compute_tax_comparison, victim, {})
+
+		# own record still readable
+		self.assertTrue(get_employee_details(attacker)["annual_gross"])
+
+	def test_notify_blocked_for_employee_role(self):
+		attacker = make_employee("ip_trs_notify_attacker@indiapayroll.com", company=COMPANY)
+		victim = make_employee("ip_trs_notify_victim@indiapayroll.com", company=COMPANY)
+		make_draft_assignment(attacker)
+		victim_ssa = make_draft_assignment(victim)
+		attacker_user = ensure_self_user_permission(attacker)
+
+		frappe.set_user(attacker_user)
+		self.assertRaises(frappe.PermissionError, notify_employee_to_select_tax_regime, victim_ssa.name)
+
+	def test_self_service_works_without_assignment_permission(self):
+		"""Most sites give the Employee role no access to Salary Structure Assignment.
+		Self-service must still work, because the guard matches user_id before it
+		checks permissions. Cross-employee access must stay blocked."""
+		employee = make_employee("ip_trs_noperm@indiapayroll.com", company=COMPANY)
+		victim = make_employee("ip_trs_noperm_victim@indiapayroll.com", company=COMPANY)
+		ssa = make_draft_assignment(employee)
+		make_draft_assignment(victim)
+		user = ensure_self_user_permission(employee)
+
+		try:
+			update_permission_property("Salary Structure Assignment", "Employee", 0, "select", 0)
+			update_permission_property("Salary Structure Assignment", "Employee", 0, "read", 0)
+			frappe.clear_cache()
+
+			frappe.set_user(user)
+			self.assertFalse(frappe.has_permission("Salary Structure Assignment", "read"))
+
+			self.assertTrue(get_employee_details(employee)["annual_gross"])
+			set_tax_regime(employee, NEW_REGIME_SLAB)
+
+			self.assertRaises(frappe.PermissionError, get_employee_details, victim)
+			self.assertRaises(frappe.PermissionError, set_tax_regime, victim, NEW_REGIME_SLAB)
+		finally:
+			frappe.set_user("Administrator")
+			reset_perms("Salary Structure Assignment")
+			frappe.clear_cache()
+
+		self.assertEqual(
+			frappe.db.get_value("Salary Structure Assignment", ssa.name, "income_tax_slab"),
+			NEW_REGIME_SLAB,
+		)
+
+	def test_setup_if_missing_blocked_for_employee_role(self):
+		employee = make_employee("ip_trs_setup@indiapayroll.com", company=COMPANY)
+		user = ensure_self_user_permission(employee)
+		self.assertTrue(setup_if_missing()["ok"])
+
+		frappe.set_user(user)
+		self.assertRaises(frappe.PermissionError, setup_if_missing)
+
+	def test_hr_user_can_set_regime_for_other_employee(self):
+		employee = make_employee("ip_trs_hr_target@indiapayroll.com", company=COMPANY)
+		ssa = make_draft_assignment(employee)
+		hr_user = make_hr_user()
+
+		frappe.set_user(hr_user)
+		set_tax_regime(employee, NEW_REGIME_SLAB)
+		self.assertTrue(get_employee_details(employee)["annual_gross"])
+
+		frappe.set_user("Administrator")
 		self.assertEqual(
 			frappe.db.get_value("Salary Structure Assignment", ssa.name, "income_tax_slab"),
 			NEW_REGIME_SLAB,

--- a/india_payroll/india_payroll/salary_slip.py
+++ b/india_payroll/india_payroll/salary_slip.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # License: GNU General Public License v3. See license.txt
 
+from india_payroll.india_payroll.employer_contributions import set_slip_employer_contributions
 from india_payroll.india_payroll.epf import apply_epf
 from india_payroll.india_payroll.esi import apply_esi
 from india_payroll.india_payroll.lwf import apply_lwf
@@ -12,3 +13,4 @@ def apply_regional_deductions(doc) -> None:
 	apply_esi(doc)
 	apply_lwf(doc)
 	apply_epf(doc)
+	set_slip_employer_contributions(doc)

--- a/india_payroll/india_payroll/test_employer_contributions.py
+++ b/india_payroll/india_payroll/test_employer_contributions.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from erpnext.setup.doctype.employee.test_employee import make_employee
+from frappe.utils import flt
+from hrms.payroll.doctype.salary_slip.test_salary_slip import make_salary_component
+from hrms.payroll.doctype.salary_structure.test_salary_structure import (
+	create_salary_structure_assignment,
+	make_salary_structure,
+)
+from hrms.tests.utils import HRMSTestSuite
+
+from india_payroll.india_payroll.esi import (
+	EMPLOYER_ESI_RATE,
+	ESI_EMPLOYER_COMPONENT,
+	ESI_WAGE_CEILING,
+)
+from india_payroll.install import create_esi_components
+
+_BASIC = "CTC Test Basic"
+_EARNINGS = [
+	{
+		"salary_component": _BASIC,
+		"abbr": "CTCB",
+		"formula": "base",
+		"type": "Earning",
+		"amount_based_on_formula": 1,
+		"depends_on_payment_days": 0,
+	}
+]
+
+
+class TestEmployerContributions(HRMSTestSuite):
+	def setUp(self):
+		create_esi_components()
+		make_salary_component(_EARNINGS, False, ["_Test Company"])
+		frappe.db.set_single_value("Payroll Settings", "enable_esic", 1)
+
+	def _make_assignment(self, email, structure_name, base, other_details=None):
+		employee = make_employee(email, company="_Test Company")
+		structure = make_salary_structure(
+			structure_name,
+			"Monthly",
+			company="_Test Company",
+			currency="INR",
+			earnings=_EARNINGS,
+			deductions=[],
+			other_details=other_details,
+		)
+		return create_salary_structure_assignment(
+			employee, structure.name, base=base, company="_Test Company", currency="INR"
+		)
+
+	def _employer_rows(self, ssa):
+		return ssa.get_evaluated_components()["employer_contributions"]
+
+	def test_employer_esi_reaches_ctc(self):
+		base = 15_000.0
+		ssa = self._make_assignment("ctc_esi@indiapayroll.com", "CTC ESI Structure", base)
+
+		rows = [r for r in self._employer_rows(ssa) if r.salary_component == ESI_EMPLOYER_COMPONENT]
+		self.assertEqual(len(rows), 1, "Employer ESI must be injected into the CTC components")
+
+		expected = flt(base * EMPLOYER_ESI_RATE, 2)  # 487.50
+		self.assertAlmostEqual(rows[0].default_amount, expected, places=2)
+
+		# CTC exceeds annual gross by exactly the employer's yearly cost
+		self.assertAlmostEqual(ssa.annual_gross_earning, base * 12, places=2)
+		self.assertAlmostEqual(ssa.ctc - ssa.annual_gross_earning, expected * 12, places=2)
+
+	def test_no_employer_esi_above_ceiling(self):
+		ssa = self._make_assignment(
+			"ctc_esi_above@indiapayroll.com", "CTC ESI Above Structure", ESI_WAGE_CEILING + 1_000
+		)
+
+		rows = [r for r in self._employer_rows(ssa) if r.salary_component == ESI_EMPLOYER_COMPONENT]
+		self.assertEqual(len(rows), 0)
+		self.assertAlmostEqual(ssa.ctc, ssa.annual_gross_earning, places=2)
+
+	def test_no_employer_esi_when_esic_disabled(self):
+		frappe.db.set_single_value("Payroll Settings", "enable_esic", 0)
+		ssa = self._make_assignment("ctc_esi_off@indiapayroll.com", "CTC ESI Off Structure", 15_000)
+
+		rows = [r for r in self._employer_rows(ssa) if r.salary_component == ESI_EMPLOYER_COMPONENT]
+		self.assertEqual(len(rows), 0)
+		self.assertAlmostEqual(ssa.ctc, ssa.annual_gross_earning, places=2)
+
+	def test_structure_row_is_upserted_not_duplicated(self):
+		"""A company that also lists the component on the structure gets the
+		statutory value, not a second row."""
+		base = 15_000.0
+		ssa = self._make_assignment(
+			"ctc_esi_dupe@indiapayroll.com",
+			"CTC ESI Duplicate Structure",
+			base,
+			other_details={
+				"employer_contributions": [
+					{"salary_component": ESI_EMPLOYER_COMPONENT, "abbr": "ERESI", "amount": 9_999}
+				]
+			},
+		)
+
+		rows = [r for r in self._employer_rows(ssa) if r.salary_component == ESI_EMPLOYER_COMPONENT]
+		self.assertEqual(len(rows), 1, "must upsert, not duplicate")
+		self.assertAlmostEqual(rows[0].default_amount, flt(base * EMPLOYER_ESI_RATE, 2), places=2)
+		self.assertAlmostEqual(
+			ssa.ctc - ssa.annual_gross_earning, flt(base * EMPLOYER_ESI_RATE, 2) * 12, places=2
+		)
+
+	def test_hook_does_not_mutate_cached_structure(self):
+		ssa = self._make_assignment("ctc_esi_cache@indiapayroll.com", "CTC ESI Cache Structure", 15_000)
+		ssa.get_evaluated_components()
+
+		cached = frappe.get_cached_doc("Salary Structure", ssa.salary_structure)
+		self.assertEqual(len(cached.employer_contributions), 0)

--- a/india_payroll/india_payroll/test_esi.py
+++ b/india_payroll/india_payroll/test_esi.py
@@ -13,10 +13,13 @@ from hrms.payroll.doctype.salary_structure.test_salary_structure import (
 from hrms.tests.utils import HRMSTestSuite
 
 from india_payroll.india_payroll.esi import (
+	EMPLOYEE_ESI_RATE,
+	EMPLOYER_ESI_RATE,
 	ESI_EMPLOYEE_COMPONENT,
-	ESI_RATE,
+	ESI_EMPLOYER_COMPONENT,
 	ESI_WAGE_CEILING,
 	ESI_WAGE_CEILING_DISABILITY,
+	get_esi_split,
 )
 from india_payroll.install import create_esi_components
 
@@ -160,7 +163,8 @@ class TestESI(HRMSTestSuite):
 	def test_eligible_employee_esi_applied(self):
 		"""
 		An employee whose gross wages are below the ₹21,000 ceiling should
-		have an ESI deduction row (4% of gross) injected on the salary slip.
+		have an employee ESI deduction row (0.75% of gross) and an employer
+		contribution row (3.25% of gross) injected on the salary slip.
 		"""
 		gross = 15_000.0
 		_, salary_slip = self._make_salary_slip(
@@ -174,8 +178,13 @@ class TestESI(HRMSTestSuite):
 
 		self.assertEqual(len(emp_rows), 1, "Employee ESI deduction row must be present")
 
-		expected_emp = flt(gross * ESI_RATE, 2)  # 600.0
-		self.assertAlmostEqual(emp_rows[0].amount, expected_emp, places=2)
+		self.assertAlmostEqual(emp_rows[0].amount, flt(gross * EMPLOYEE_ESI_RATE, 2), places=2)  # 112.50
+
+		employer_rows = [
+			d for d in salary_slip.employer_contributions if d.salary_component == ESI_EMPLOYER_COMPONENT
+		]
+		self.assertEqual(len(employer_rows), 1, "Employer ESI contribution row must be present")
+		self.assertAlmostEqual(employer_rows[0].amount, flt(gross * EMPLOYER_ESI_RATE, 2), places=2)  # 487.50
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 1})
 	def test_employee_at_exact_ceiling_is_eligible(self):
@@ -194,8 +203,7 @@ class TestESI(HRMSTestSuite):
 		emp_rows = [d for d in salary_slip.deductions if d.salary_component == ESI_EMPLOYEE_COMPONENT]
 		self.assertEqual(len(emp_rows), 1, "Employee at exact ceiling must be eligible")
 
-		expected_emp = flt(gross * ESI_RATE, 2)  # 840.0
-		self.assertAlmostEqual(emp_rows[0].amount, expected_emp, places=2)
+		self.assertAlmostEqual(emp_rows[0].amount, flt(gross * EMPLOYEE_ESI_RATE, 2), places=2)  # 157.50
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 1})
 	def test_employee_above_ceiling_no_esi(self):
@@ -211,8 +219,8 @@ class TestESI(HRMSTestSuite):
 		)
 		salary_slip.insert()
 
-		esi_rows = [d for d in salary_slip.deductions if d.salary_component == ESI_EMPLOYEE_COMPONENT]
-		self.assertEqual(len(esi_rows), 0, "Employee above ceiling must not have ESI rows")
+		self.assertEqual(len(self._esi_rows(salary_slip)), 0, "Employee above ceiling must not have ESI rows")
+		self.assertEqual(len(self._employer_esi_rows(salary_slip)), 0)
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 1})
 	def test_person_with_disability_uses_higher_ceiling(self):
@@ -238,7 +246,7 @@ class TestESI(HRMSTestSuite):
 			"Person with disability earning 23,000 must be eligible (ceiling is 25,000)",
 		)
 
-		expected_emp = flt(gross * ESI_RATE, 2)  # 920.0
+		expected_emp = flt(gross * EMPLOYEE_ESI_RATE, 2)  # 172.50
 		self.assertAlmostEqual(emp_rows[0].amount, expected_emp, places=2)
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 1})
@@ -257,8 +265,10 @@ class TestESI(HRMSTestSuite):
 
 		salary_slip.insert()
 
-		esi_rows = [d for d in salary_slip.deductions if d.salary_component == ESI_EMPLOYEE_COMPONENT]
-		self.assertEqual(len(esi_rows), 0, "Person with disability above 25,000 must not have ESI rows")
+		self.assertEqual(
+			len(self._esi_rows(salary_slip)), 0, "Person with disability above 25,000 must not have ESI rows"
+		)
+		self.assertEqual(len(self._employer_esi_rows(salary_slip)), 0)
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 0})
 	def test_esi_not_applied_when_disabled(self):
@@ -274,13 +284,16 @@ class TestESI(HRMSTestSuite):
 		)
 		salary_slip.insert()
 
-		esi_rows = [d for d in salary_slip.deductions if d.salary_component == ESI_EMPLOYEE_COMPONENT]
-		self.assertEqual(len(esi_rows), 0, "ESI must not be applied when setting is disabled")
+		self.assertEqual(
+			len(self._esi_rows(salary_slip)), 0, "ESI must not be applied when setting is disabled"
+		)
+		self.assertEqual(len(self._employer_esi_rows(salary_slip)), 0)
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 1})
 	def test_net_pay_reduced_by_employee_esi(self):
 		"""
-		Net pay must be reduced exactly by the full ESI amount (4% of gross).
+		Net pay must be reduced by the employee's 0.75% share only. The employer's
+		3.25% sits in employer_contributions and must not touch gross or net.
 		"""
 		gross = 20_000.0
 		_, salary_slip = self._make_salary_slip(
@@ -290,18 +303,24 @@ class TestESI(HRMSTestSuite):
 		)
 		salary_slip.insert()
 
-		expected_esi = flt(gross * ESI_RATE, 2)  # 800.0
+		expected_employee = flt(gross * EMPLOYEE_ESI_RATE, 2)  # 150.0
 		self.assertAlmostEqual(
 			salary_slip.net_pay,
-			gross - expected_esi,
+			gross - expected_employee,
 			places=2,
-			msg="net_pay must equal gross_pay minus ESI",
+			msg="net_pay must equal gross_pay minus the employee ESI share",
 		)
+		self.assertAlmostEqual(salary_slip.gross_pay, gross, places=2)
+
+		employer_rows = [
+			d for d in salary_slip.employer_contributions if d.salary_component == ESI_EMPLOYER_COMPONENT
+		]
+		self.assertAlmostEqual(employer_rows[0].amount, flt(gross * EMPLOYER_ESI_RATE, 2), places=2)  # 650.0
 
 		emp_esi_in_deduction = sum(
 			flt(d.amount) for d in salary_slip.deductions if d.salary_component == ESI_EMPLOYEE_COMPONENT
 		)
-		self.assertAlmostEqual(emp_esi_in_deduction, expected_esi, places=2)
+		self.assertAlmostEqual(emp_esi_in_deduction, expected_employee, places=2)
 
 	def _make_lop_salary_slip(self, email: str, structure_name: str, base: float):
 		"""Build (uninserted) a salary slip whose single earning prorates with payment
@@ -330,6 +349,10 @@ class TestESI(HRMSTestSuite):
 	@staticmethod
 	def _esi_rows(slip):
 		return [d for d in slip.deductions if d.salary_component == ESI_EMPLOYEE_COMPONENT]
+
+	@staticmethod
+	def _employer_esi_rows(slip):
+		return [d for d in slip.employer_contributions if d.salary_component == ESI_EMPLOYER_COMPONENT]
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 1})
 	def test_eligibility_uses_full_gross_not_prorated(self):
@@ -371,14 +394,52 @@ class TestESI(HRMSTestSuite):
 		)
 		slip.insert()
 
-		# Full month: ESI on 20,000 = 800.
-		self.assertAlmostEqual(self._esi_rows(slip)[0].amount, flt(20_000 * ESI_RATE, 2), places=2)
+		# Full month: employee ESI on 20,000 = 150.
+		self.assertAlmostEqual(self._esi_rows(slip)[0].amount, flt(20_000 * EMPLOYEE_ESI_RATE, 2), places=2)
 
 		# Half-month LOP: still covered (full gross 20,000 ≤ ceiling), contribution on
-		# the 10,000 actually paid → 400.
+		# the 10,000 actually paid → 75.
 		slip.total_working_days = 30
 		slip.payment_days = 15
 		slip.calculate_net_pay()
 
 		self.assertAlmostEqual(slip.gross_pay, 10_000, places=2)
-		self.assertAlmostEqual(self._esi_rows(slip)[0].amount, flt(10_000 * ESI_RATE, 2), places=2)
+		self.assertAlmostEqual(self._esi_rows(slip)[0].amount, flt(10_000 * EMPLOYEE_ESI_RATE, 2), places=2)
+
+	def test_get_esi_split_shares_sum_to_four_percent(self):
+		split = get_esi_split(20_000)
+
+		self.assertTrue(split.covered)
+		self.assertAlmostEqual(split.employee, 150.0, places=2)
+		self.assertAlmostEqual(split.employer, 650.0, places=2)
+		self.assertAlmostEqual(split.total, 800.0, places=2)
+
+	def test_get_esi_split_ceiling_is_inclusive(self):
+		self.assertTrue(get_esi_split(ESI_WAGE_CEILING).covered)
+		self.assertFalse(get_esi_split(ESI_WAGE_CEILING + 1).covered)
+
+		self.assertTrue(get_esi_split(ESI_WAGE_CEILING_DISABILITY, is_person_with_disability=True).covered)
+		self.assertFalse(
+			get_esi_split(ESI_WAGE_CEILING_DISABILITY + 1, is_person_with_disability=True).covered
+		)
+
+	def test_get_esi_split_not_covered_is_all_zero(self):
+		split = get_esi_split(ESI_WAGE_CEILING + 1)
+
+		self.assertFalse(split.covered)
+		self.assertEqual(split.employee, 0.0)
+		self.assertEqual(split.employer, 0.0)
+		self.assertEqual(split.total, 0.0)
+
+	def test_get_esi_split_ceiling_gross_decides_coverage(self):
+		"""Coverage follows ``ceiling_gross`` while the contribution follows ``gross``.
+
+		This is what keeps an LOP month honest: a 22,000 earner paid 10,000 stays
+		out of ESI, and a 20,000 earner paid 10,000 contributes on the 10,000.
+		"""
+		self.assertFalse(get_esi_split(10_000, ceiling_gross=22_000).covered)
+
+		split = get_esi_split(10_000, ceiling_gross=20_000)
+		self.assertTrue(split.covered)
+		self.assertAlmostEqual(split.employee, 75.0, places=2)
+		self.assertAlmostEqual(split.employer, 325.0, places=2)

--- a/india_payroll/india_payroll/test_esi.py
+++ b/india_payroll/india_payroll/test_esi.py
@@ -394,11 +394,11 @@ class TestESI(HRMSTestSuite):
 		)
 		slip.insert()
 
-		# Full month: employee ESI on 20,000 = 150.
+		# full month: employee ESI on 20,000 = 150
 		self.assertAlmostEqual(self._esi_rows(slip)[0].amount, flt(20_000 * EMPLOYEE_ESI_RATE, 2), places=2)
 
 		# Half-month LOP: still covered (full gross 20,000 ≤ ceiling), contribution on
-		# the 10,000 actually paid → 75.
+		# the 10,000 actually paid = 75
 		slip.total_working_days = 30
 		slip.payment_days = 15
 		slip.calculate_net_pay()

--- a/india_payroll/india_payroll/test_esi.py
+++ b/india_payroll/india_payroll/test_esi.py
@@ -69,6 +69,7 @@ class TestESI(HRMSTestSuite):
 			"test_esi_net_pay@indiapayroll.com",
 			"test_esi_lop_eligibility@indiapayroll.com",
 			"test_esi_lop_contribution@indiapayroll.com",
+			"test_esi_missing_employer_component@indiapayroll.com",
 		]
 		create_esi_components()
 		self._ensure_esi_test_components()
@@ -185,6 +186,33 @@ class TestESI(HRMSTestSuite):
 		]
 		self.assertEqual(len(employer_rows), 1, "Employer ESI contribution row must be present")
 		self.assertAlmostEqual(employer_rows[0].amount, flt(gross * EMPLOYER_ESI_RATE, 2), places=2)  # 487.50
+
+	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 1})
+	def test_employee_esi_applied_when_employer_component_missing(self):
+		"""
+		The employee's 0.75% deduction must not depend on the employer component.
+		A site missing "Employer State Insurance" still owes the employee share,
+		and gating both together silently dropped it from every slip.
+		"""
+		frappe.db.delete("Salary Component", {"name": ESI_EMPLOYER_COMPONENT})
+		self.assertFalse(frappe.db.exists("Salary Component", ESI_EMPLOYER_COMPONENT))
+
+		gross = 15_000.0
+		_, salary_slip = self._make_salary_slip(
+			"test_esi_missing_employer_component@indiapayroll.com",
+			"Test ESI Missing Employer Structure",
+			gross,
+		)
+		salary_slip.insert()
+
+		emp_rows = [d for d in salary_slip.deductions if d.salary_component == ESI_EMPLOYEE_COMPONENT]
+		self.assertEqual(len(emp_rows), 1, "Employee ESI must apply without the employer component")
+		self.assertAlmostEqual(emp_rows[0].amount, flt(gross * EMPLOYEE_ESI_RATE, 2), places=2)
+
+		employer_rows = [
+			d for d in salary_slip.employer_contributions if d.salary_component == ESI_EMPLOYER_COMPONENT
+		]
+		self.assertEqual(len(employer_rows), 0, "No employer row without the component")
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_esic": 1})
 	def test_employee_at_exact_ceiling_is_eligible(self):

--- a/india_payroll/install.py
+++ b/india_payroll/install.py
@@ -647,18 +647,15 @@ def create_professional_tax_component():
 
 def create_esi_components():
 	"""
-	Create the Employee State Insurance salary component if it does not
+	Create the two Employee State Insurance salary components if they do not
 	already exist.
 
-	Only the employee's deduction (0.75 %) is tracked as a salary component.
-	The employer's contribution (3.25 %) is part of the CTC and is not shown
-	as a separate component on the salary slip.
+	The employee's 0.75 % is a deduction that reduces net pay. The employer's
+	3.25 % uses the "Employer Contribution" component type: it is a cost the
+	employer bears on top of gross, shown on the salary slip for transparency
+	without affecting gross, total deduction or net pay.
 	"""
-	if frappe.db.exists("Salary Component", "Employee State Insurance"):
-		return
-
-	doc = frappe.new_doc("Salary Component")
-	doc.update(
+	components = [
 		{
 			"salary_component": "Employee State Insurance",
 			"salary_component_abbr": "ESI",
@@ -668,9 +665,26 @@ def create_esi_components():
 				"Employee's contribution to the Employee State Insurance scheme "
 				"at 0.75% of gross wages (ESI Act, 1948)."
 			),
-		}
-	)
-	doc.insert(ignore_permissions=True)
+		},
+		{
+			"salary_component": "Employer State Insurance",
+			"salary_component_abbr": "ERESI",
+			"type": "Employer Contribution",
+			"description": (
+				"Employer's contribution to the Employee State Insurance scheme "
+				"at 3.25% of gross wages (ESI Act, 1948). Part of CTC; does not "
+				"reduce net pay."
+			),
+		},
+	]
+
+	for component in components:
+		if frappe.db.exists("Salary Component", component["salary_component"]):
+			continue
+
+		doc = frappe.new_doc("Salary Component")
+		doc.update(component)
+		doc.insert(ignore_permissions=True)
 
 
 def create_lwf_component():

--- a/india_payroll/install.py
+++ b/india_payroll/install.py
@@ -647,13 +647,10 @@ def create_professional_tax_component():
 
 def create_esi_components():
 	"""
-	Create the two Employee State Insurance salary components if they do not
-	already exist.
+	Create the two Employee State Insurance salary components.
 
-	The employee's 0.75 % is a deduction that reduces net pay. The employer's
-	3.25 % uses the "Employer Contribution" component type: it is a cost the
-	employer bears on top of gross, shown on the salary slip for transparency
-	without affecting gross, total deduction or net pay.
+	The employee's 0.75 % reduces net pay; the employer's 3.25 % is a cost borne
+	on top of gross and does not.
 	"""
 	components = [
 		{

--- a/india_payroll/patches.txt
+++ b/india_payroll/patches.txt
@@ -13,3 +13,4 @@ india_payroll.patches.v1_0.move_statutory_config_to_salary_structure_assignment
 india_payroll.patches.v1_0.consolidate_employee_india_payroll_section #2
 india_payroll.patches.v1_0.set_tds_sandbox_mode_from_conf
 india_payroll.patches.v1_0.fix_tds_depends_on_expressions
+india_payroll.patches.v1_0.add_employer_esi_component

--- a/india_payroll/patches/v1_0/add_employer_esi_component.py
+++ b/india_payroll/patches/v1_0/add_employer_esi_component.py
@@ -1,0 +1,18 @@
+import frappe
+
+
+def execute():
+	"""
+	Create the Employer State Insurance salary component.
+
+	The employer's 3.25% ESI share had no component to sit on, so it was folded
+	into the single Employee State Insurance deduction and taken out of the
+	employee's net pay. It is now an Employer Contribution shown on the salary
+	slip instead.
+
+	Re-runnable: create_esi_components skips components that already exist.
+	"""
+	from india_payroll.install import create_esi_components
+
+	create_esi_components()
+	frappe.clear_cache(doctype="Salary Component")

--- a/india_payroll/patches/v1_0/add_employer_esi_component.py
+++ b/india_payroll/patches/v1_0/add_employer_esi_component.py
@@ -5,12 +5,8 @@ def execute():
 	"""
 	Create the Employer State Insurance salary component.
 
-	The employer's 3.25% ESI share had no component to sit on, so it was folded
-	into the single Employee State Insurance deduction and taken out of the
-	employee's net pay. It is now an Employer Contribution shown on the salary
-	slip instead.
-
-	Re-runnable: create_esi_components skips components that already exist.
+	The employer's 3.25% share had no component to sit on, so it was folded into
+	the employee's deduction. Re-runnable: existing components are skipped.
 	"""
 	from india_payroll.install import create_esi_components
 

--- a/india_payroll/public/js/tax_regime_selector/controller.js
+++ b/india_payroll/public/js/tax_regime_selector/controller.js
@@ -86,7 +86,12 @@ export class TaxRegimeSelector {
 		this.annual_gross_control.refresh();
 
 		this.fetch_payroll_period();
-		frappe.call({ method: `${METHOD}.setup_if_missing` });
+		if (
+			frappe.model.can_create("Income Tax Slab") &&
+			frappe.model.can_create("Employee Tax Exemption Category")
+		) {
+			frappe.call({ method: `${METHOD}.setup_if_missing` });
+		}
 
 		// Default to the logged-in user's employee, if any.
 		window.hrms?.get_current_employee?.().then((employee) => {


### PR DESCRIPTION
The missing ESI component for employer contribution is now added to the list of default components. It also splits ESI into employer and employee instead of clubbing it as one 4% deduction.
<img width="1605" height="900" alt="image" src="https://github.com/user-attachments/assets/bcd271b9-8c38-4ac6-8817-ae6dc10fb5b1" />

depends on frappe/hrms#5149
closes #65