### PR TITLE
feat: Multi-company India Payroll

### DIFF
--- a/india_payroll/hooks.py
+++ b/india_payroll/hooks.py
@@ -193,7 +193,10 @@ doc_events = {
 		"validate": "india_payroll.india_payroll.professional_tax.validate_employment_state",
 	},
 	"Payroll Settings": {
-		"validate": "india_payroll.india_payroll.tds.settings.clear_token_cache_on_change",
+		"validate": [
+			"india_payroll.india_payroll.tds.settings.clear_token_cache_on_change",
+			"india_payroll.india_payroll.company_settings.validate_company_payroll_settings",
+		],
 	},
 	"Company": {
 		"validate": "india_payroll.india_payroll.tds.settings.validate_deductor_details",

--- a/india_payroll/india_payroll/company_settings.py
+++ b/india_payroll/india_payroll/company_settings.py
@@ -69,6 +69,26 @@ def is_statutory_enabled(statute: str, company: str | None = None) -> bool:
 	return get_company_setting(company) is not None
 
 
+def get_applicable_companies(statute: str) -> list[str] | None:
+	"""Companies a statutory register may report `statute` liabilities for.
+
+	`None` means no company restriction — multi-company payroll is off and
+	every company follows the single global configuration, so reports keep
+	their previous behaviour. A list means multi-company payroll is on and
+	only the listed companies participate; an empty list means no company
+	does, so the register must be empty.
+	"""
+	settings = frappe.get_cached_doc("Payroll Settings")
+
+	if not settings.get(MULTI_COMPANY_FIELD):
+		return None
+
+	if not settings.get(STATUTE_TOGGLE_FIELDS[statute]):
+		return []
+
+	return [row.company for row in settings.get(COMPANY_SETTINGS_FIELD) or [] if row.company]
+
+
 def get_registration_number(statute: str, company: str | None = None) -> str | None:
 	"""Registration identifier for `statute`, per company when multi-company is on."""
 	settings = frappe.get_cached_doc("Payroll Settings")

--- a/india_payroll/india_payroll/company_settings.py
+++ b/india_payroll/india_payroll/company_settings.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from frappe import _
+
+MULTI_COMPANY_FIELD = "enable_multi_company_payroll"
+COMPANY_SETTINGS_FIELD = "company_payroll_settings"
+
+STATUTE_TOGGLE_FIELDS = {
+	"professional_tax": "enable_professional_tax",
+	"esic": "enable_esic",
+	"lwf": "enable_lwf",
+	"epf": "enable_epf",
+}
+
+STATUTE_REGISTRATION_FIELDS = {
+	"esic": "esic_registration_number",
+	"epf": "epf_establishment_code",
+	"professional_tax": "professional_tax_registration_number",
+	"lwf": "lwf_registration_number",
+}
+
+GLOBAL_REGISTRATION_FIELDS = {
+	"esic": "esic_registration_number",
+	"epf": "epf_establishment_code",
+}
+
+REGISTRATION_LABELS = {
+	"esic": "ESIC Registration Number",
+	"epf": "EPF Establishment Code",
+	"professional_tax": "Professional Tax Registration Number",
+	"lwf": "LWF Registration Number",
+}
+
+
+def is_multi_company_enabled() -> bool:
+	return bool(frappe.get_cached_value("Payroll Settings", "Payroll Settings", MULTI_COMPANY_FIELD))
+
+
+def get_company_setting(company: str | None) -> "frappe._dict | None":
+	if not company:
+		return None
+
+	settings = frappe.get_cached_doc("Payroll Settings")
+	for row in settings.get(COMPANY_SETTINGS_FIELD) or []:
+		if row.company == company:
+			return frappe._dict(row.as_dict())
+
+	return None
+
+
+def is_statutory_enabled(statute: str, company: str | None = None) -> bool:
+	"""Whether `statute` applies to `company`.
+
+	The top-level Payroll Settings check is the master switch. When
+	multi-company payroll is on, only companies listed in the company
+	settings table participate; a company with no row is treated as
+	not configured and gets no statutory deduction.
+	"""
+	settings = frappe.get_cached_doc("Payroll Settings")
+
+	if not settings.get(STATUTE_TOGGLE_FIELDS[statute]):
+		return False
+
+	if not settings.get(MULTI_COMPANY_FIELD):
+		return True
+
+	return get_company_setting(company) is not None
+
+
+def get_registration_number(statute: str, company: str | None = None) -> str | None:
+	"""Registration identifier for `statute`, per company when multi-company is on."""
+	settings = frappe.get_cached_doc("Payroll Settings")
+
+	if settings.get(MULTI_COMPANY_FIELD):
+		row = get_company_setting(company)
+		return row.get(STATUTE_REGISTRATION_FIELDS[statute]) if row else None
+
+	global_field = GLOBAL_REGISTRATION_FIELDS.get(statute)
+	return settings.get(global_field) if global_field else None
+
+
+def validate_company_payroll_settings(doc, method=None) -> None:
+	rows = doc.get(COMPANY_SETTINGS_FIELD) or []
+
+	seen = {}
+	for row in rows:
+		for fieldname in STATUTE_REGISTRATION_FIELDS.values():
+			value = row.get(fieldname)
+			if value:
+				row.set(fieldname, value.strip())
+
+		if row.company in seen:
+			frappe.throw(
+				_("Row #{0}: Company {1} is already configured in row #{2}.").format(
+					row.idx, frappe.bold(row.company), seen[row.company]
+				),
+				title=_("Duplicate Company"),
+			)
+		seen[row.company] = row.idx
+
+	if doc.get(MULTI_COMPANY_FIELD) and not rows:
+		frappe.throw(
+			_(
+				"Add at least one company to the Company Payroll Settings table. "
+				"With multi-company payroll enabled, statutory deductions are applied "
+				"only to companies listed there."
+			),
+			title=_("No Company Configured"),
+		)

--- a/india_payroll/india_payroll/doctype/india_payroll_company_setting/india_payroll_company_setting.json
+++ b/india_payroll/india_payroll/doctype/india_payroll_company_setting/india_payroll_company_setting.json
@@ -1,0 +1,78 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-08-27 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "company",
+  "esic_registration_number",
+  "epf_establishment_code",
+  "column_break_registrations",
+  "professional_tax_registration_number",
+  "lwf_registration_number"
+ ],
+ "fields": [
+  {
+   "columns": 2,
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "columns": 2,
+   "description": "17-digit ESIC employer code for this company.",
+   "fieldname": "esic_registration_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "ESIC Registration Number",
+   "translatable": 0
+  },
+  {
+   "columns": 2,
+   "description": "EPFO Establishment Code used in this company's ECR file header.",
+   "fieldname": "epf_establishment_code",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "EPF Establishment Code",
+   "translatable": 0
+  },
+  {
+   "fieldname": "column_break_registrations",
+   "fieldtype": "Column Break"
+  },
+  {
+   "columns": 2,
+   "description": "State Professional Tax enrolment / registration number.",
+   "fieldname": "professional_tax_registration_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Professional Tax Registration Number",
+   "translatable": 0
+  },
+  {
+   "columns": 2,
+   "description": "State Labour Welfare Fund establishment registration number.",
+   "fieldname": "lwf_registration_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "LWF Registration Number",
+   "translatable": 0
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-27 00:00:00.000000",
+ "module": "India Payroll",
+ "name": "India Payroll Company Setting",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/india_payroll/india_payroll/doctype/india_payroll_company_setting/india_payroll_company_setting.py
+++ b/india_payroll/india_payroll/doctype/india_payroll_company_setting/india_payroll_company_setting.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class IndiaPayrollCompanySetting(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		company: DF.Link
+		epf_establishment_code: DF.Data | None
+		esic_registration_number: DF.Data | None
+		lwf_registration_number: DF.Data | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		professional_tax_registration_number: DF.Data | None
+	# end: auto-generated types
+
+	pass

--- a/india_payroll/india_payroll/epf.py
+++ b/india_payroll/india_payroll/epf.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.utils import flt
 
+from india_payroll.india_payroll.company_settings import is_statutory_enabled
 from india_payroll.india_payroll.utils import get_slip_ssa_values
 
 # Employee deductions (reduce net pay).  Employer EPF/EPS/EDLI/Admin are
@@ -42,7 +43,7 @@ def apply_epf(doc, method=None) -> None:
 	Gated by a single `epf_applicable` flag on the Salary Structure Assignment.
 	All employees are assumed to be post-1 Sept 2014 EPF members.
 	"""
-	if not frappe.db.get_single_value("Payroll Settings", "enable_epf"):
+	if not is_statutory_enabled("epf", doc.company):
 		_remove_epf_components(doc)
 		return
 

--- a/india_payroll/india_payroll/esi.py
+++ b/india_payroll/india_payroll/esi.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.utils import flt
 
+from india_payroll.india_payroll.company_settings import is_statutory_enabled
 from india_payroll.india_payroll.utils import get_slip_ssa_values
 
 ESI_EMPLOYEE_COMPONENT = "Employee State Insurance"
@@ -25,7 +26,8 @@ def apply_esi(doc, method=None) -> None:
 	so a high earner is not wrongly pulled into ESI in an LOP month. The
 	contribution itself is still levied on the actual wages paid (``gross_pay``).
 	"""
-	if not frappe.db.get_single_value("Payroll Settings", "enable_esic"):
+	if not is_statutory_enabled("esic", doc.company):
+		_remove_esi_components(doc)
 		return
 
 	if not doc.salary_structure:

--- a/india_payroll/india_payroll/lwf.py
+++ b/india_payroll/india_payroll/lwf.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.utils import flt, getdate
 
+from india_payroll.india_payroll.company_settings import is_statutory_enabled
 from india_payroll.india_payroll.utils import get_slip_ssa_values
 
 LWF_SALARY_COMPONENT = "Labour Welfare Fund"
@@ -47,7 +48,8 @@ def apply_lwf(doc, method=None) -> None:
 	  • The deduction month rule for that state's frequency
 	  • Whether the employee is manually exempted (lwf_exempted field)
 	"""
-	if not frappe.db.get_single_value("Payroll Settings", "enable_lwf"):
+	if not is_statutory_enabled("lwf", doc.company):
+		_remove_lwf_component(doc)
 		return
 
 	if not doc.salary_structure:

--- a/india_payroll/india_payroll/professional_tax.py
+++ b/india_payroll/india_payroll/professional_tax.py
@@ -4,6 +4,7 @@ import frappe
 from frappe.query_builder.functions import Sum
 from frappe.utils import flt, getdate
 
+from india_payroll.india_payroll.company_settings import is_statutory_enabled
 from india_payroll.india_payroll.utils import get_slip_ssa_values
 
 PT_SALARY_COMPONENT = "Professional Tax"
@@ -199,7 +200,8 @@ def apply_professional_tax(doc, method=None) -> None:
 	Only mutates ``doc.deductions``; the slip's ``set_net_pay`` (which runs
 	immediately after this hook in ``calculate_net_pay``) recomputes totals.
 	"""
-	if not frappe.db.get_single_value("Payroll Settings", "enable_professional_tax"):
+	if not is_statutory_enabled("professional_tax", doc.company):
+		_update_pt_in_salary_slip(doc, 0)
 		return
 
 	if not doc.salary_structure:
@@ -241,7 +243,7 @@ def validate_employment_state(doc, method=None) -> None:
 	employment_state set. A warning (not a hard error) is shown so that
 	users can still save assignments for states not yet covered by PT rules.
 	"""
-	if not frappe.db.get_single_value("Payroll Settings", "enable_professional_tax"):
+	if not is_statutory_enabled("professional_tax", doc.company):
 		return
 
 	if frappe.flags.in_test:

--- a/india_payroll/india_payroll/report/employee_provident_fund_register/employee_provident_fund_register.py
+++ b/india_payroll/india_payroll/report/employee_provident_fund_register/employee_provident_fund_register.py
@@ -150,8 +150,6 @@ def get_data(filters):
 	date_range = _get_date_range(filters)
 
 	applicable_companies = get_applicable_companies("epf")
-	if applicable_companies is not None and not applicable_companies:
-		return []
 
 	SS = DocType("Salary Slip")
 	Emp = DocType("Employee")
@@ -180,8 +178,6 @@ def get_data(filters):
 
 	if filters.get("company"):
 		query = query.where(SS.company == filters["company"])
-	if applicable_companies is not None:
-		query = query.where(SS.company.isin(applicable_companies))
 	if date_range:
 		query = query.where(SS.start_date >= date_range["from_date"])
 		query = query.where(SS.start_date <= date_range["to_date"])
@@ -213,6 +209,7 @@ def get_data(filters):
 		return []
 
 	totals_by_slip = _aggregate_salary_detail([s.slip for s in slips])
+	slips = _filter_in_scope(slips, totals_by_slip, applicable_companies)
 
 	data = []
 	for s in slips:
@@ -261,6 +258,28 @@ def get_data(filters):
 		)
 
 	return data
+
+
+def _filter_in_scope(slips, totals_by_slip, applicable_companies):
+	"""Drop slips whose company is outside EPF scope, keeping those that already
+	recorded an employee EPF or VPF contribution.
+
+	A company removed from Company Payroll Settings stops accruing new EPF, but
+	the contributions it already deducted have been remitted against its
+	establishment code, so past months must stay reportable and re-exportable.
+	"""
+	if applicable_companies is None:
+		return slips
+
+	return [
+		s
+		for s in slips
+		if s.company in applicable_companies or _has_epf_contribution(totals_by_slip.get(s.slip, {}))
+	]
+
+
+def _has_epf_contribution(totals: dict) -> bool:
+	return flt(totals.get(EPF_EMPLOYEE_COMPONENT)) > 0 or flt(totals.get(VPF_COMPONENT)) > 0
 
 
 def _aggregate_salary_detail(slip_names: list[str]) -> dict:

--- a/india_payroll/india_payroll/report/employee_provident_fund_register/employee_provident_fund_register.py
+++ b/india_payroll/india_payroll/report/employee_provident_fund_register/employee_provident_fund_register.py
@@ -8,6 +8,10 @@ from frappe import _
 from frappe.query_builder import DocType
 from frappe.utils import flt
 
+from india_payroll.india_payroll.company_settings import (
+	get_applicable_companies,
+	is_multi_company_enabled,
+)
 from india_payroll.india_payroll.epf import (
 	EPF_EMPLOYEE_COMPONENT,
 	EPF_EMPLOYER_RATE,
@@ -145,6 +149,10 @@ def get_columns():
 def get_data(filters):
 	date_range = _get_date_range(filters)
 
+	applicable_companies = get_applicable_companies("epf")
+	if applicable_companies is not None and not applicable_companies:
+		return []
+
 	SS = DocType("Salary Slip")
 	Emp = DocType("Employee")
 
@@ -172,6 +180,8 @@ def get_data(filters):
 
 	if filters.get("company"):
 		query = query.where(SS.company == filters["company"])
+	if applicable_companies is not None:
+		query = query.where(SS.company.isin(applicable_companies))
 	if date_range:
 		query = query.where(SS.start_date >= date_range["from_date"])
 		query = query.where(SS.start_date <= date_range["to_date"])
@@ -354,9 +364,20 @@ def get_ecr_file(filters: dict | str) -> dict:
 	if isinstance(filters, str):
 		filters = frappe.parse_json(filters)
 
-	rows = get_data(filters or {})
+	filters = filters or {}
+
+	if is_multi_company_enabled() and not filters.get("company"):
+		frappe.throw(
+			_(
+				"Select a Company before generating the ECR file. Each ECR file is filed "
+				"against a single EPF Establishment Code, and {0} is enabled in Payroll Settings."
+			).format(frappe.bold(_("Multi-Company Payroll"))),
+			title=_("Company Required"),
+		)
+
+	rows = get_data(filters)
 	if not rows:
-		return {"filename": _ecr_filename(filters or {}), "content": "", "row_count": 0}
+		return {"filename": _ecr_filename(filters), "content": "", "row_count": 0}
 
 	missing = [r["employee"] for r in rows if not r.get("uan_number")]
 	if missing:
@@ -383,7 +404,7 @@ def get_ecr_file(filters: dict | str) -> dict:
 		)
 
 	return {
-		"filename": _ecr_filename(filters or {}),
+		"filename": _ecr_filename(filters),
 		"content": "\n".join(lines),
 		"row_count": len(lines),
 	}

--- a/india_payroll/india_payroll/report/esic_register/esic_register.py
+++ b/india_payroll/india_payroll/report/esic_register/esic_register.py
@@ -9,7 +9,8 @@ from frappe.query_builder import DocType
 from frappe.utils import flt
 
 from india_payroll.india_payroll.company_settings import get_applicable_companies
-from india_payroll.india_payroll.utils import get_effective_ssa_values
+from india_payroll.india_payroll.esi import ESI_EMPLOYEE_COMPONENT
+from india_payroll.india_payroll.utils import get_effective_ssa_values, get_slips_with_deduction
 
 # Statutory rates (ESI Act, 1948 — effective July 2019)
 EMPLOYEE_ESI_RATE = 0.0075  # 0.75 %
@@ -118,8 +119,6 @@ def get_data(filters):
 	date_range = _get_date_range(filters)
 
 	applicable_companies = get_applicable_companies("esic")
-	if applicable_companies is not None and not applicable_companies:
-		return []
 
 	SS = DocType("Salary Slip")
 	Emp = DocType("Employee")
@@ -129,6 +128,7 @@ def get_data(filters):
 		.join(Emp)
 		.on(Emp.name == SS.employee)
 		.select(
+			SS.name.as_("slip"),
 			SS.employee,
 			SS.company,
 			SS.salary_structure,
@@ -144,9 +144,6 @@ def get_data(filters):
 	if filters.get("company"):
 		query = query.where(SS.company == filters["company"])
 
-	if applicable_companies is not None:
-		query = query.where(SS.company.isin(applicable_companies))
-
 	if date_range:
 		query = query.where(SS.start_date >= date_range["from_date"])
 		query = query.where(SS.start_date <= date_range["to_date"])
@@ -156,6 +153,7 @@ def get_data(filters):
 		query = query.select(Emp.esic_card_no)
 
 	rows = query.run(as_dict=True)
+	rows = _filter_in_scope(rows, applicable_companies)
 
 	coverage_filter = filters.get("coverage_status")
 
@@ -202,6 +200,21 @@ def get_data(filters):
 		)
 
 	return data
+
+
+def _filter_in_scope(rows, applicable_companies):
+	"""Drop slips whose company is outside ESIC scope, keeping those that already
+	recorded an ESI deduction.
+
+	A company removed from Company Payroll Settings stops accruing new ESI, but
+	the contributions it already deducted remain part of the filed record and
+	must stay reportable.
+	"""
+	if applicable_companies is None:
+		return rows
+
+	with_esi = get_slips_with_deduction([r.slip for r in rows], [ESI_EMPLOYEE_COMPONENT])
+	return [r for r in rows if r.company in applicable_companies or r.slip in with_esi]
 
 
 def _get_date_range(filters):

--- a/india_payroll/india_payroll/report/esic_register/esic_register.py
+++ b/india_payroll/india_payroll/report/esic_register/esic_register.py
@@ -8,6 +8,7 @@ from frappe import _
 from frappe.query_builder import DocType
 from frappe.utils import flt
 
+from india_payroll.india_payroll.company_settings import get_applicable_companies
 from india_payroll.india_payroll.utils import get_effective_ssa_values
 
 # Statutory rates (ESI Act, 1948 — effective July 2019)
@@ -116,6 +117,10 @@ def get_columns():
 def get_data(filters):
 	date_range = _get_date_range(filters)
 
+	applicable_companies = get_applicable_companies("esic")
+	if applicable_companies is not None and not applicable_companies:
+		return []
+
 	SS = DocType("Salary Slip")
 	Emp = DocType("Employee")
 
@@ -138,6 +143,9 @@ def get_data(filters):
 
 	if filters.get("company"):
 		query = query.where(SS.company == filters["company"])
+
+	if applicable_companies is not None:
+		query = query.where(SS.company.isin(applicable_companies))
 
 	if date_range:
 		query = query.where(SS.start_date >= date_range["from_date"])

--- a/india_payroll/india_payroll/report/lwf_register/lwf_register.py
+++ b/india_payroll/india_payroll/report/lwf_register/lwf_register.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.query_builder import DocType
 from frappe.utils import flt, getdate
 
+from india_payroll.india_payroll.company_settings import get_applicable_companies
 from india_payroll.india_payroll.lwf import LWF_STATE_CONFIG, _is_deduction_month
 from india_payroll.india_payroll.utils import get_effective_ssa_values
 
@@ -109,6 +110,10 @@ def get_data(filters):
 	state_filter = filters.get("work_state")
 	status_filter = filters.get("deduction_status")
 
+	applicable_companies = get_applicable_companies("lwf")
+	if applicable_companies is not None and not applicable_companies:
+		return []
+
 	SS = DocType("Salary Slip")
 	Emp = DocType("Employee")
 
@@ -130,6 +135,9 @@ def get_data(filters):
 
 	if filters.get("company"):
 		query = query.where(SS.company == filters["company"])
+
+	if applicable_companies is not None:
+		query = query.where(SS.company.isin(applicable_companies))
 
 	if date_range:
 		query = query.where(SS.start_date >= date_range["from_date"])

--- a/india_payroll/india_payroll/report/lwf_register/lwf_register.py
+++ b/india_payroll/india_payroll/report/lwf_register/lwf_register.py
@@ -7,8 +7,8 @@ from frappe.query_builder import DocType
 from frappe.utils import flt, getdate
 
 from india_payroll.india_payroll.company_settings import get_applicable_companies
-from india_payroll.india_payroll.lwf import LWF_STATE_CONFIG, _is_deduction_month
-from india_payroll.india_payroll.utils import get_effective_ssa_values
+from india_payroll.india_payroll.lwf import LWF_SALARY_COMPONENT, LWF_STATE_CONFIG, _is_deduction_month
+from india_payroll.india_payroll.utils import get_effective_ssa_values, get_slips_with_deduction
 
 _MONTHS = {
 	"January": 1,
@@ -111,8 +111,6 @@ def get_data(filters):
 	status_filter = filters.get("deduction_status")
 
 	applicable_companies = get_applicable_companies("lwf")
-	if applicable_companies is not None and not applicable_companies:
-		return []
 
 	SS = DocType("Salary Slip")
 	Emp = DocType("Employee")
@@ -122,6 +120,7 @@ def get_data(filters):
 		.join(Emp)
 		.on(Emp.name == SS.employee)
 		.select(
+			SS.name.as_("slip"),
 			SS.employee,
 			SS.start_date,
 			SS.salary_structure,
@@ -136,14 +135,12 @@ def get_data(filters):
 	if filters.get("company"):
 		query = query.where(SS.company == filters["company"])
 
-	if applicable_companies is not None:
-		query = query.where(SS.company.isin(applicable_companies))
-
 	if date_range:
 		query = query.where(SS.start_date >= date_range["from_date"])
 		query = query.where(SS.start_date <= date_range["to_date"])
 
 	rows = query.run(as_dict=True)
+	rows = _filter_in_scope(rows, applicable_companies)
 
 	data = []
 	for row in rows:
@@ -205,6 +202,21 @@ def get_data(filters):
 		)
 
 	return data
+
+
+def _filter_in_scope(rows, applicable_companies):
+	"""Drop slips whose company is outside LWF scope, keeping those that already
+	recorded an LWF deduction.
+
+	A company removed from Company Payroll Settings stops accruing new LWF, but
+	the contributions it already deducted remain remittable and must stay
+	reportable.
+	"""
+	if applicable_companies is None:
+		return rows
+
+	with_lwf = get_slips_with_deduction([r.slip for r in rows], [LWF_SALARY_COMPONENT])
+	return [r for r in rows if r.company in applicable_companies or r.slip in with_lwf]
 
 
 def _get_date_range(filters):

--- a/india_payroll/india_payroll/test_company_settings.py
+++ b/india_payroll/india_payroll/test_company_settings.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from hrms.tests.utils import HRMSTestSuite
+
+from india_payroll.india_payroll.company_settings import (
+	COMPANY_SETTINGS_FIELD,
+	MULTI_COMPANY_FIELD,
+	get_registration_number,
+	is_statutory_enabled,
+	validate_company_payroll_settings,
+)
+
+_COMPANY_A = "India Payroll MC Company A"
+_COMPANY_B = "India Payroll MC Company B"
+
+
+def create_company(name: str, abbr: str) -> str:
+	if not frappe.db.exists("Company", name):
+		frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company_name": name,
+				"abbr": abbr,
+				"default_currency": "INR",
+				"country": "India",
+			}
+		).insert()
+	return name
+
+
+class TestCompanyPayrollSettings(HRMSTestSuite):
+	def setUp(self):
+		create_company(_COMPANY_A, "IPMCA")
+		create_company(_COMPANY_B, "IPMCB")
+		self.settings = frappe.get_doc("Payroll Settings")
+
+	def tearDown(self):
+		frappe.db.rollback()
+		frappe.clear_cache(doctype="Payroll Settings")
+
+	def _apply(self, values: dict, rows: list[dict] | None = None):
+		settings = frappe.get_doc("Payroll Settings")
+		settings.update(values)
+		settings.set(COMPANY_SETTINGS_FIELD, [])
+		for row in rows or []:
+			settings.append(COMPANY_SETTINGS_FIELD, row)
+		settings.flags.ignore_permissions = True
+		settings.save()
+		frappe.clear_cache(doctype="Payroll Settings")
+		return settings
+
+	def test_single_company_mode_unaffected(self):
+		self._apply(
+			{
+				MULTI_COMPANY_FIELD: 0,
+				"enable_esic": 1,
+				"enable_epf": 0,
+				"esic_registration_number": "31000123450000",
+			}
+		)
+
+		self.assertTrue(is_statutory_enabled("esic", _COMPANY_A))
+		self.assertTrue(is_statutory_enabled("esic", _COMPANY_B))
+		self.assertFalse(is_statutory_enabled("epf", _COMPANY_A))
+		self.assertEqual(get_registration_number("esic", _COMPANY_A), "31000123450000")
+
+	def test_configured_company_uses_its_own_registrations(self):
+		self._apply(
+			{MULTI_COMPANY_FIELD: 1, "enable_esic": 1, "enable_epf": 1},
+			[
+				{
+					"company": _COMPANY_A,
+					"esic_registration_number": "31000123450000",
+					"epf_establishment_code": "MHBAN0012345",
+				}
+			],
+		)
+
+		self.assertTrue(is_statutory_enabled("esic", _COMPANY_A))
+		self.assertEqual(get_registration_number("esic", _COMPANY_A), "31000123450000")
+		self.assertEqual(get_registration_number("epf", _COMPANY_A), "MHBAN0012345")
+
+	def test_unconfigured_company_is_not_applicable(self):
+		self._apply(
+			{MULTI_COMPANY_FIELD: 1, "enable_esic": 1, "enable_lwf": 1},
+			[{"company": _COMPANY_A, "esic_registration_number": "31000123450000"}],
+		)
+
+		self.assertFalse(is_statutory_enabled("esic", _COMPANY_B))
+		self.assertFalse(is_statutory_enabled("lwf", _COMPANY_B))
+		self.assertIsNone(get_registration_number("esic", _COMPANY_B))
+
+	def test_global_toggle_still_gates_configured_company(self):
+		self._apply(
+			{MULTI_COMPANY_FIELD: 1, "enable_esic": 0},
+			[{"company": _COMPANY_A, "esic_registration_number": "31000123450000"}],
+		)
+
+		self.assertFalse(is_statutory_enabled("esic", _COMPANY_A))
+
+	def test_global_registration_ignored_in_multi_company_mode(self):
+		self._apply(
+			{MULTI_COMPANY_FIELD: 1, "enable_esic": 1, "esic_registration_number": "99999999999999999"},
+			[{"company": _COMPANY_A, "esic_registration_number": "31000123450000"}],
+		)
+
+		self.assertEqual(get_registration_number("esic", _COMPANY_A), "31000123450000")
+
+	def test_duplicate_company_rejected(self):
+		doc = frappe.get_doc("Payroll Settings")
+		doc.set(MULTI_COMPANY_FIELD, 1)
+		doc.set(COMPANY_SETTINGS_FIELD, [])
+		doc.append(COMPANY_SETTINGS_FIELD, {"company": _COMPANY_A})
+		doc.append(COMPANY_SETTINGS_FIELD, {"company": _COMPANY_A})
+
+		self.assertRaises(frappe.ValidationError, validate_company_payroll_settings, doc)
+
+	def test_multi_company_without_rows_rejected(self):
+		doc = frappe.get_doc("Payroll Settings")
+		doc.set(MULTI_COMPANY_FIELD, 1)
+		doc.set(COMPANY_SETTINGS_FIELD, [])
+
+		self.assertRaises(frappe.ValidationError, validate_company_payroll_settings, doc)
+
+	def test_registration_numbers_are_stripped(self):
+		doc = frappe.get_doc("Payroll Settings")
+		doc.set(MULTI_COMPANY_FIELD, 1)
+		doc.set(COMPANY_SETTINGS_FIELD, [])
+		doc.append(
+			COMPANY_SETTINGS_FIELD,
+			{"company": _COMPANY_A, "esic_registration_number": "  31000123450000  "},
+		)
+
+		validate_company_payroll_settings(doc)
+
+		self.assertEqual(doc.get(COMPANY_SETTINGS_FIELD)[0].esic_registration_number, "31000123450000")

--- a/india_payroll/india_payroll/test_company_settings.py
+++ b/india_payroll/india_payroll/test_company_settings.py
@@ -7,6 +7,7 @@ from hrms.tests.utils import HRMSTestSuite
 from india_payroll.india_payroll.company_settings import (
 	COMPANY_SETTINGS_FIELD,
 	MULTI_COMPANY_FIELD,
+	get_applicable_companies,
 	get_registration_number,
 	is_statutory_enabled,
 	validate_company_payroll_settings,
@@ -123,6 +124,30 @@ class TestCompanyPayrollSettings(HRMSTestSuite):
 		doc.set(COMPANY_SETTINGS_FIELD, [])
 
 		self.assertRaises(frappe.ValidationError, validate_company_payroll_settings, doc)
+
+	def test_applicable_companies_unrestricted_in_single_company_mode(self):
+		self._apply({MULTI_COMPANY_FIELD: 0, "enable_esic": 1, "enable_lwf": 1, "enable_epf": 1})
+
+		for statute in ("esic", "lwf", "epf"):
+			self.assertIsNone(get_applicable_companies(statute))
+
+	def test_applicable_companies_limited_to_configured_rows(self):
+		self._apply(
+			{MULTI_COMPANY_FIELD: 1, "enable_esic": 1, "enable_lwf": 1, "enable_epf": 1},
+			[{"company": _COMPANY_A, "esic_registration_number": "31000123450000"}],
+		)
+
+		for statute in ("esic", "lwf", "epf"):
+			self.assertEqual(get_applicable_companies(statute), [_COMPANY_A])
+
+	def test_applicable_companies_empty_when_statute_globally_off(self):
+		self._apply(
+			{MULTI_COMPANY_FIELD: 1, "enable_esic": 0, "enable_lwf": 1},
+			[{"company": _COMPANY_A}],
+		)
+
+		self.assertEqual(get_applicable_companies("esic"), [])
+		self.assertEqual(get_applicable_companies("lwf"), [_COMPANY_A])
 
 	def test_registration_numbers_are_stripped(self):
 		doc = frappe.get_doc("Payroll Settings")

--- a/india_payroll/india_payroll/test_report_company_gate.py
+++ b/india_payroll/india_payroll/test_report_company_gate.py
@@ -15,6 +15,9 @@ from india_payroll.india_payroll.company_settings import (
 	COMPANY_SETTINGS_FIELD,
 	MULTI_COMPANY_FIELD,
 )
+from india_payroll.india_payroll.epf import EPF_EMPLOYEE_COMPONENT
+from india_payroll.india_payroll.esi import ESI_EMPLOYEE_COMPONENT
+from india_payroll.india_payroll.lwf import LWF_SALARY_COMPONENT
 from india_payroll.india_payroll.report.employee_provident_fund_register import (
 	employee_provident_fund_register as epf_register,
 )
@@ -26,8 +29,15 @@ from india_payroll.install import create_epf_components, create_esi_components, 
 _SLIP_COMPANY = "_Test Company"
 _OTHER_COMPANY = "India Payroll MC Company A"
 
-_EMAIL = "test_mc_report_gate@indiapayroll.com"
+_HISTORICAL_EMAIL = "test_mc_gate_historical@indiapayroll.com"
+_NEW_EMAIL = "test_mc_gate_new@indiapayroll.com"
 _STRUCTURE = "Test MC Report Gate Structure"
+
+_UAN = {
+	_HISTORICAL_EMAIL: "100200300401",
+	_NEW_EMAIL: "100200300402",
+}
+
 _BASIC_COMPONENT = "MC Gate Basic"
 _EARNINGS = [
 	{
@@ -40,12 +50,15 @@ _EARNINGS = [
 	}
 ]
 
-_START = "2026-04-01"
-_END = "2026-04-30"
-_FILTERS = {"month": "April", "year": "2026"}
+_START = "2026-05-01"
+_END = "2026-05-31"
+_FILTERS = {"month": "May", "year": "2026"}
 
 
 class TestReportCompanyGate(HRMSTestSuite):
+	"""Removing a company from Company Payroll Settings must stop new statutory
+	accrual without erasing what the company already deducted and remitted."""
+
 	def setUp(self):
 		create_esi_components()
 		create_lwf_component()
@@ -55,57 +68,54 @@ class TestReportCompanyGate(HRMSTestSuite):
 		if not frappe.db.exists("Salary Component", _BASIC_COMPONENT):
 			make_salary_component(_EARNINGS, False, [_SLIP_COMPANY])
 
-		frappe.db.delete("Salary Slip", {"employee_name": _EMAIL})
-		emp = frappe.db.get_value("Employee", {"employee_name": _EMAIL}, "name")
-		if emp:
-			frappe.db.delete("Salary Structure Assignment", {"employee": emp})
+		self._cleanup()
 
-		self._disable_multi_company()
-		self.slip = self._make_submitted_slip()
+		self._configure(multi_company=False)
+		self.historical_slip = self._make_submitted_slip(_HISTORICAL_EMAIL)
+
+		self._configure(multi_company=True)
+		self.new_slip = self._make_submitted_slip(_NEW_EMAIL)
 
 	def tearDown(self):
 		frappe.db.rollback()
 		frappe.clear_cache(doctype="Payroll Settings")
 
-	def _save_settings(self, values: dict, rows: list[dict] | None = None):
+	def _cleanup(self):
+		for email in (_HISTORICAL_EMAIL, _NEW_EMAIL):
+			frappe.db.delete("Salary Slip", {"employee_name": email})
+			emp = frappe.db.get_value("Employee", {"employee_name": email}, "name")
+			if emp:
+				frappe.db.delete("Salary Structure Assignment", {"employee": emp})
+
+	def _configure(self, multi_company: bool):
+		"""Enable every statute. When `multi_company` is set, list only a company
+		the slips do not belong to, so _Test Company is out of scope."""
 		settings = frappe.get_doc("Payroll Settings")
 		settings.email_salary_slip_to_employee = 0
-		settings.update(values)
-		settings.set(COMPANY_SETTINGS_FIELD, [])
-		for row in rows or []:
-			settings.append(COMPANY_SETTINGS_FIELD, row)
-		settings.flags.ignore_permissions = True
-		settings.save()
-		frappe.clear_cache(doctype="Payroll Settings")
-
-	def _disable_multi_company(self):
-		self._save_settings(
+		settings.update(
 			{
-				MULTI_COMPANY_FIELD: 0,
+				MULTI_COMPANY_FIELD: int(multi_company),
 				"enable_esic": 1,
 				"enable_lwf": 1,
 				"enable_epf": 1,
 			}
 		)
+		settings.set(COMPANY_SETTINGS_FIELD, [])
+		if multi_company:
+			settings.append(
+				COMPANY_SETTINGS_FIELD,
+				{"company": _OTHER_COMPANY, "esic_registration_number": "31000123450000"},
+			)
+		settings.flags.ignore_permissions = True
+		settings.save()
+		frappe.clear_cache(doctype="Payroll Settings")
 
-	def _exclude_slip_company(self):
-		"""Turn on multi-company payroll listing only a company the slip does not belong to."""
-		self._save_settings(
-			{
-				MULTI_COMPANY_FIELD: 1,
-				"enable_esic": 1,
-				"enable_lwf": 1,
-				"enable_epf": 1,
-			},
-			[{"company": _OTHER_COMPANY, "esic_registration_number": "31000123450000"}],
-		)
-
-	def _make_submitted_slip(self):
-		employee = make_employee(_EMAIL, company=_SLIP_COMPANY)
+	def _make_submitted_slip(self, email: str):
+		employee = make_employee(email, company=_SLIP_COMPANY)
 		frappe.db.set_value(
 			"Employee",
 			employee,
-			{"uan_number": "100200300400", "pf_name": "MC Gate Test"},
+			{"uan_number": _UAN[email], "pf_name": "MC Gate Test"},
 		)
 		structure = make_salary_structure(
 			_STRUCTURE,
@@ -122,7 +132,6 @@ class TestReportCompanyGate(HRMSTestSuite):
 			company=_SLIP_COMPANY,
 			base=15_000,
 		)
-
 		ssa = frappe.db.get_value(
 			"Salary Structure Assignment", {"employee": employee}, "name", order_by="from_date desc"
 		)
@@ -139,41 +148,63 @@ class TestReportCompanyGate(HRMSTestSuite):
 		slip.submit()
 		return slip
 
-	def _rows_for_slip(self, report):
-		return [r for r in report.get_data(dict(_FILTERS)) if r["employee"] == self.slip.employee]
+	def _employees_in(self, report):
+		return {r["employee"] for r in report.get_data(dict(_FILTERS))}
 
-	def test_esic_register_includes_slip_before_exclusion(self):
-		self.assertEqual(len(self._rows_for_slip(esic_register)), 1)
+	def _deduction_components(self, slip_name):
+		return set(
+			frappe.get_all(
+				"Salary Detail",
+				filters={"parent": slip_name, "parentfield": "deductions", "amount": (">", 0)},
+				pluck="salary_component",
+			)
+		)
 
-	def test_esic_register_excludes_unconfigured_company(self):
-		self._exclude_slip_company()
-		self.assertEqual(self._rows_for_slip(esic_register), [])
+	def test_fixture_records_deductions_only_before_exclusion(self):
+		historical = self._deduction_components(self.historical_slip.name)
+		self.assertIn(ESI_EMPLOYEE_COMPONENT, historical)
+		self.assertIn(LWF_SALARY_COMPONENT, historical)
+		self.assertIn(EPF_EMPLOYEE_COMPONENT, historical)
 
-	def test_lwf_register_includes_slip_before_exclusion(self):
-		self.assertEqual(len(self._rows_for_slip(lwf_register)), 1)
+		new = self._deduction_components(self.new_slip.name)
+		self.assertNotIn(ESI_EMPLOYEE_COMPONENT, new)
+		self.assertNotIn(LWF_SALARY_COMPONENT, new)
+		self.assertNotIn(EPF_EMPLOYEE_COMPONENT, new)
 
-	def test_lwf_register_excludes_unconfigured_company(self):
-		self._exclude_slip_company()
-		self.assertEqual(self._rows_for_slip(lwf_register), [])
+	def test_esic_register_keeps_already_deducted_liability(self):
+		self.assertIn(self.historical_slip.employee, self._employees_in(esic_register))
 
-	def test_epf_register_includes_slip_before_exclusion(self):
-		self.assertEqual(len(self._rows_for_slip(epf_register)), 1)
+	def test_esic_register_drops_post_exclusion_slip(self):
+		self.assertNotIn(self.new_slip.employee, self._employees_in(esic_register))
 
-	def test_epf_register_excludes_unconfigured_company(self):
-		self._exclude_slip_company()
-		self.assertEqual(self._rows_for_slip(epf_register), [])
+	def test_lwf_register_keeps_already_deducted_liability(self):
+		self.assertIn(self.historical_slip.employee, self._employees_in(lwf_register))
 
-	def test_ecr_file_excludes_unconfigured_company(self):
-		self._exclude_slip_company()
+	def test_lwf_register_drops_post_exclusion_slip(self):
+		self.assertNotIn(self.new_slip.employee, self._employees_in(lwf_register))
+
+	def test_epf_register_keeps_already_deducted_liability(self):
+		self.assertIn(self.historical_slip.employee, self._employees_in(epf_register))
+
+	def test_epf_register_drops_post_exclusion_slip(self):
+		self.assertNotIn(self.new_slip.employee, self._employees_in(epf_register))
+
+	def test_ecr_file_remains_reproducible_after_exclusion(self):
 		result = epf_register.get_ecr_file({**_FILTERS, "company": _SLIP_COMPANY})
-		self.assertEqual(result["row_count"], 0)
-		self.assertEqual(result["content"], "")
+
+		historical_uan = frappe.db.get_value("Employee", self.historical_slip.employee, "uan_number")
+		new_uan = frappe.db.get_value("Employee", self.new_slip.employee, "uan_number")
+
+		self.assertIn(f"{historical_uan}#~#", result["content"])
+		self.assertNotIn(f"{new_uan}#~#", result["content"])
 
 	def test_ecr_file_requires_company_in_multi_company_mode(self):
-		self._exclude_slip_company()
 		self.assertRaises(frappe.ValidationError, epf_register.get_ecr_file, dict(_FILTERS))
 
-	def test_ecr_file_includes_slip_in_single_company_mode(self):
-		result = epf_register.get_ecr_file(dict(_FILTERS))
-		self.assertEqual(result["row_count"], 1)
-		self.assertTrue(result["content"].startswith("100200300400#~#"))
+	def test_both_slips_reported_when_multi_company_off(self):
+		self._configure(multi_company=False)
+
+		for report in (esic_register, lwf_register, epf_register):
+			employees = self._employees_in(report)
+			self.assertIn(self.historical_slip.employee, employees)
+			self.assertIn(self.new_slip.employee, employees)

--- a/india_payroll/india_payroll/test_report_company_gate.py
+++ b/india_payroll/india_payroll/test_report_company_gate.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from erpnext.setup.doctype.employee.test_employee import make_employee
+from hrms.payroll.doctype.salary_slip.test_salary_slip import make_salary_component
+from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
+from hrms.payroll.doctype.salary_structure.test_salary_structure import (
+	create_salary_structure_assignment,
+	make_salary_structure,
+)
+from hrms.tests.utils import HRMSTestSuite
+
+from india_payroll.india_payroll.company_settings import (
+	COMPANY_SETTINGS_FIELD,
+	MULTI_COMPANY_FIELD,
+)
+from india_payroll.india_payroll.report.employee_provident_fund_register import (
+	employee_provident_fund_register as epf_register,
+)
+from india_payroll.india_payroll.report.esic_register import esic_register
+from india_payroll.india_payroll.report.lwf_register import lwf_register
+from india_payroll.india_payroll.test_company_settings import create_company
+from india_payroll.install import create_epf_components, create_esi_components, create_lwf_component
+
+_SLIP_COMPANY = "_Test Company"
+_OTHER_COMPANY = "India Payroll MC Company A"
+
+_EMAIL = "test_mc_report_gate@indiapayroll.com"
+_STRUCTURE = "Test MC Report Gate Structure"
+_BASIC_COMPONENT = "MC Gate Basic"
+_EARNINGS = [
+	{
+		"salary_component": _BASIC_COMPONENT,
+		"abbr": "MCGB",
+		"formula": "base",
+		"type": "Earning",
+		"amount_based_on_formula": 1,
+		"depends_on_payment_days": 0,
+	}
+]
+
+_START = "2026-04-01"
+_END = "2026-04-30"
+_FILTERS = {"month": "April", "year": "2026"}
+
+
+class TestReportCompanyGate(HRMSTestSuite):
+	def setUp(self):
+		create_esi_components()
+		create_lwf_component()
+		create_epf_components()
+		create_company(_OTHER_COMPANY, "IPMCA")
+
+		if not frappe.db.exists("Salary Component", _BASIC_COMPONENT):
+			make_salary_component(_EARNINGS, False, [_SLIP_COMPANY])
+
+		frappe.db.delete("Salary Slip", {"employee_name": _EMAIL})
+		emp = frappe.db.get_value("Employee", {"employee_name": _EMAIL}, "name")
+		if emp:
+			frappe.db.delete("Salary Structure Assignment", {"employee": emp})
+
+		self._disable_multi_company()
+		self.slip = self._make_submitted_slip()
+
+	def tearDown(self):
+		frappe.db.rollback()
+		frappe.clear_cache(doctype="Payroll Settings")
+
+	def _save_settings(self, values: dict, rows: list[dict] | None = None):
+		settings = frappe.get_doc("Payroll Settings")
+		settings.email_salary_slip_to_employee = 0
+		settings.update(values)
+		settings.set(COMPANY_SETTINGS_FIELD, [])
+		for row in rows or []:
+			settings.append(COMPANY_SETTINGS_FIELD, row)
+		settings.flags.ignore_permissions = True
+		settings.save()
+		frappe.clear_cache(doctype="Payroll Settings")
+
+	def _disable_multi_company(self):
+		self._save_settings(
+			{
+				MULTI_COMPANY_FIELD: 0,
+				"enable_esic": 1,
+				"enable_lwf": 1,
+				"enable_epf": 1,
+			}
+		)
+
+	def _exclude_slip_company(self):
+		"""Turn on multi-company payroll listing only a company the slip does not belong to."""
+		self._save_settings(
+			{
+				MULTI_COMPANY_FIELD: 1,
+				"enable_esic": 1,
+				"enable_lwf": 1,
+				"enable_epf": 1,
+			},
+			[{"company": _OTHER_COMPANY, "esic_registration_number": "31000123450000"}],
+		)
+
+	def _make_submitted_slip(self):
+		employee = make_employee(_EMAIL, company=_SLIP_COMPANY)
+		frappe.db.set_value(
+			"Employee",
+			employee,
+			{"uan_number": "100200300400", "pf_name": "MC Gate Test"},
+		)
+		structure = make_salary_structure(
+			_STRUCTURE,
+			"Monthly",
+			company=_SLIP_COMPANY,
+			currency="INR",
+			earnings=_EARNINGS,
+			deductions=[],
+		)
+		create_salary_structure_assignment(
+			employee,
+			structure.name,
+			from_date=_START,
+			company=_SLIP_COMPANY,
+			base=15_000,
+		)
+
+		ssa = frappe.db.get_value(
+			"Salary Structure Assignment", {"employee": employee}, "name", order_by="from_date desc"
+		)
+		frappe.db.set_value(
+			"Salary Structure Assignment",
+			ssa,
+			{"employment_state": "Haryana", "epf_applicable": 1},
+		)
+
+		slip = make_salary_slip(structure.name, employee=employee, posting_date=_START)
+		slip.start_date = _START
+		slip.end_date = _END
+		slip.insert()
+		slip.submit()
+		return slip
+
+	def _rows_for_slip(self, report):
+		return [r for r in report.get_data(dict(_FILTERS)) if r["employee"] == self.slip.employee]
+
+	def test_esic_register_includes_slip_before_exclusion(self):
+		self.assertEqual(len(self._rows_for_slip(esic_register)), 1)
+
+	def test_esic_register_excludes_unconfigured_company(self):
+		self._exclude_slip_company()
+		self.assertEqual(self._rows_for_slip(esic_register), [])
+
+	def test_lwf_register_includes_slip_before_exclusion(self):
+		self.assertEqual(len(self._rows_for_slip(lwf_register)), 1)
+
+	def test_lwf_register_excludes_unconfigured_company(self):
+		self._exclude_slip_company()
+		self.assertEqual(self._rows_for_slip(lwf_register), [])
+
+	def test_epf_register_includes_slip_before_exclusion(self):
+		self.assertEqual(len(self._rows_for_slip(epf_register)), 1)
+
+	def test_epf_register_excludes_unconfigured_company(self):
+		self._exclude_slip_company()
+		self.assertEqual(self._rows_for_slip(epf_register), [])
+
+	def test_ecr_file_excludes_unconfigured_company(self):
+		self._exclude_slip_company()
+		result = epf_register.get_ecr_file({**_FILTERS, "company": _SLIP_COMPANY})
+		self.assertEqual(result["row_count"], 0)
+		self.assertEqual(result["content"], "")
+
+	def test_ecr_file_requires_company_in_multi_company_mode(self):
+		self._exclude_slip_company()
+		self.assertRaises(frappe.ValidationError, epf_register.get_ecr_file, dict(_FILTERS))
+
+	def test_ecr_file_includes_slip_in_single_company_mode(self):
+		result = epf_register.get_ecr_file(dict(_FILTERS))
+		self.assertEqual(result["row_count"], 1)
+		self.assertTrue(result["content"].startswith("100200300400#~#"))

--- a/india_payroll/india_payroll/utils.py
+++ b/india_payroll/india_payroll/utils.py
@@ -29,3 +29,27 @@ def get_effective_ssa_values(
 
 def get_slip_ssa_values(doc, fields: list[str]) -> "frappe._dict":
 	return get_effective_ssa_values(doc.employee, doc.company, doc.salary_structure, doc.end_date, fields)
+
+
+def get_slips_with_deduction(slip_names: list[str], components: list[str]) -> set[str]:
+	"""Names of the given slips that actually carry one of `components` as a deduction.
+
+	A statutory deduction row is only ever written with a positive amount, so its
+	presence is the slip's own record that the liability was incurred for that
+	period — independent of how Payroll Settings is configured today.
+	"""
+	if not slip_names or not components:
+		return set()
+
+	rows = frappe.get_all(
+		"Salary Detail",
+		filters={
+			"parenttype": "Salary Slip",
+			"parent": ("in", slip_names),
+			"parentfield": "deductions",
+			"salary_component": ("in", components),
+			"amount": (">", 0),
+		},
+		pluck="parent",
+	)
+	return set(rows)

--- a/india_payroll/install.py
+++ b/india_payroll/install.py
@@ -158,11 +158,38 @@ def get_custom_fields():
 				"insert_after": "create_overtime_slip",
 			},
 			{
-				"fieldname": "india_payroll_professional_tax_section",
-				"label": "Professional Tax",
+				"fieldname": "india_payroll_multi_company_section",
+				"label": "Multi-Company Payroll",
 				"fieldtype": "Section Break",
 				"insert_after": "india_payroll_tab",
 				"collapsible": 1,
+				"collapsible_depends_on": "eval:doc.enable_multi_company_payroll",
+			},
+			{
+				"fieldname": "enable_multi_company_payroll",
+				"label": "Enable Multi-Company Payroll",
+				"fieldtype": "Check",
+				"insert_after": "india_payroll_multi_company_section",
+				"description": (
+					"Maintain statutory registration details separately for each company. "
+					"When enabled, statutory deductions apply only to companies listed below."
+				),
+			},
+			{
+				"fieldname": "company_payroll_settings",
+				"label": "Company Payroll Settings",
+				"fieldtype": "Table",
+				"options": "India Payroll Company Setting",
+				"insert_after": "enable_multi_company_payroll",
+				"depends_on": "eval:doc.enable_multi_company_payroll",
+			},
+			{
+				"fieldname": "india_payroll_professional_tax_section",
+				"label": "Professional Tax",
+				"fieldtype": "Section Break",
+				"insert_after": "company_payroll_settings",
+				"collapsible": 1,
+				"collapsible_depends_on": "eval:doc.enable_professional_tax",
 			},
 			{
 				"fieldname": "enable_professional_tax",
@@ -176,6 +203,7 @@ def get_custom_fields():
 				"fieldtype": "Section Break",
 				"insert_after": "enable_professional_tax",
 				"collapsible": 1,
+				"collapsible_depends_on": "eval:doc.enable_esic",
 			},
 			{
 				"fieldname": "enable_esic",
@@ -188,7 +216,7 @@ def get_custom_fields():
 				"label": "ESIC Registration Number",
 				"fieldtype": "Data",
 				"insert_after": "enable_esic",
-				"depends_on": "eval:doc.enable_esic",
+				"depends_on": "eval:doc.enable_esic && !doc.enable_multi_company_payroll",
 				"translatable": 0,
 			},
 			{
@@ -197,6 +225,7 @@ def get_custom_fields():
 				"fieldtype": "Section Break",
 				"insert_after": "esic_registration_number",
 				"collapsible": 1,
+				"collapsible_depends_on": "eval:doc.enable_lwf",
 			},
 			{
 				"fieldname": "enable_lwf",
@@ -210,6 +239,7 @@ def get_custom_fields():
 				"fieldtype": "Section Break",
 				"insert_after": "enable_lwf",
 				"collapsible": 1,
+				"collapsible_depends_on": "eval:doc.enable_epf",
 			},
 			{
 				"fieldname": "enable_epf",
@@ -222,7 +252,7 @@ def get_custom_fields():
 				"label": "EPF Establishment Code",
 				"fieldtype": "Data",
 				"insert_after": "enable_epf",
-				"depends_on": "eval:doc.enable_epf",
+				"depends_on": "eval:doc.enable_epf && !doc.enable_multi_company_payroll",
 				"translatable": 0,
 				"description": "EPFO Establishment Code used in the ECR file header.",
 			},
@@ -232,6 +262,7 @@ def get_custom_fields():
 				"fieldtype": "Section Break",
 				"insert_after": "epf_establishment_code",
 				"collapsible": 1,
+				"collapsible_depends_on": "eval:doc.enable_tds_filing",
 				"description": (
 					"Credentials for filing quarterly salary TDS returns (Form 24Q) "
 					"through the Sandbox API (sandbox.co.in)."


### PR DESCRIPTION
## Multi-company support in India Payroll Settings

Payroll Settings is a Single doctype, so until now a bench could hold exactly one set of India Payroll statutory registration details. A group running two or more entities had nowhere to record a second ESIC employer code or EPF establishment code.

This PR adds an opt-in multi-company mode: a child table on Payroll Settings holding one row of statutory registration details per company.

### What's added

**New child doctype — `India Payroll Company Setting`**

| Field | Type |
| --- | --- |
| Company | Link → Company (required) |
| ESIC Registration Number | Data |
| EPF Establishment Code | Data |
| Professional Tax Registration Number | Data |
| LWF Registration Number | Data |

**Two custom fields on Payroll Settings**, at the top of the India Payroll tab:

- `enable_multi_company_payroll` (Check)
- `company_payroll_settings` (Table → India Payroll Company Setting), shown only when the check is on

**New module — `india_payroll/india_payroll/company_settings.py`**, the single place that resolves statutory config:

- `is_statutory_enabled(statute, company)`
- `get_registration_number(statute, company)`
- `validate_company_payroll_settings(doc)` — wired as a Payroll Settings `validate` hook

### Behaviour

The existing top-level `enable_professional_tax` / `enable_esic` / `enable_lwf` / `enable_epf` checks stay as the master switches.

- **Multi-company off** — nothing changes. Existing installs behave exactly as before.
- **Multi-company on** — only companies listed in the table participate. A company with no row is treated as not configured: no statutory deduction is applied and its registration numbers resolve to `None`.

The global ESIC Registration Number and EPF Establishment Code fields are hidden while multi-company mode is on, so there is never a question about which value is live.

The four statutory gates and the Salary Structure Assignment `validate_employment_state` check now resolve through `is_statutory_enabled(...)` with the document's company:

- `esi.py:29`
- `epf.py:46`
- `lwf.py:51`
- `professional_tax.py:203`, `professional_tax.py:240`

### Validation on save

- Duplicate company rows are rejected, naming both row numbers
- Registration numbers are stripped of surrounding whitespace
- Enabling multi-company with an empty table is rejected — otherwise the toggle would silently switch off every statutory deduction across the bench

### Behaviour change worth reviewing

ESI, LWF and Professional Tax previously returned early when disabled, leaving any previously injected deduction row on the slip. EPF already stripped its rows in that path. All four now strip consistently.

This is required for the feature: removing a company from the table (or unchecking a statute) has to actually clear that company's deductions when a slip is re-saved, not leave a stale row behind. All existing statutory tests pass unchanged.

### Migration

None required. `esic_registration_number` and `epf_establishment_code` were declared on Payroll Settings but not read anywhere in the codebase yet, so there are no live values to move into the table. If those fields are later wired into the ECR file or ESIC register output, a patch seeding a row for the default company would be worth adding then.
