### PR TITLE
fix: EPF calcualtion logic

### DIFF
--- a/india_payroll/india_payroll/epf.py
+++ b/india_payroll/india_payroll/epf.py
@@ -100,15 +100,16 @@ def apply_epf(doc, method=None) -> None:
 
 	pf_wage = _compute_pf_wage(doc)
 	if pf_wage <= 0:
-		frappe.msgprint(
-			frappe._(
-				"No Basic or Dearness Allowance earning was found on this Salary Slip, "
-				"so no EPF has been deducted. EPF applies only to Basic and Dearness "
-				"Allowance; rename the component accordingly if it is PF-eligible."
-			),
-			indicator="orange",
-			alert=True,
-		)
+		if not _has_pf_wage_component(doc):
+			frappe.msgprint(
+				frappe._(
+					"No Basic or Dearness Allowance earning was found on this Salary Slip, "
+					"so no EPF has been deducted. EPF applies only to Basic and Dearness "
+					"Allowance; rename the component accordingly if it is PF-eligible."
+				),
+				indicator="orange",
+				alert=True,
+			)
 		_remove_epf_components(doc)
 		return
 
@@ -141,18 +142,21 @@ def _required_components_exist() -> bool:
 	return True
 
 
-def _compute_pf_wage(doc) -> float:
-	total = 0.0
-	for e in doc.earnings:
-		# Skip anything injected from an Additional Salary (bonuses/arrears).
-		if e.get("additional_salary"):
-			continue
-		# Count only Basic / Dearness Allowance.
-		if not is_pf_wage_component(e.salary_component):
-			continue
-		total += flt(e.default_amount)
+def _is_pf_wage_row(e) -> bool:
+	# Additional Salary earnings (bonuses/arrears) never count, even when the
+	# component reads as Basic/DA.
+	return not e.get("additional_salary") and is_pf_wage_component(e.salary_component)
 
-	return total
+
+def _has_pf_wage_component(doc) -> bool:
+	return any(_is_pf_wage_row(e) for e in doc.earnings)
+
+
+def _compute_pf_wage(doc) -> float:
+	# `amount`, not `default_amount`: for components that depend on payment days
+	# this is the LOP-prorated wage actually paid, which is what the EPF
+	# register and the ECR report as EPF wages.
+	return sum(flt(e.amount) for e in doc.earnings if _is_pf_wage_row(e))
 
 
 def _compute_monthly_epf_base(monthly_pf_wage: float, *, contribute_on_actual: bool) -> float:

--- a/india_payroll/india_payroll/epf.py
+++ b/india_payroll/india_payroll/epf.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # License: GNU General Public License v3. See license.txt
 
+import re
+
 import frappe
 from frappe.utils import flt
 
@@ -26,6 +28,28 @@ EPS_RATE = 0.0833  # employer's pension diversion
 EDLI_RATE = 0.005  # employer's EDLI premium
 EPF_ADMIN_RATE = 0.005  # employer's EPF admin charges
 
+PF_WAGE_COMPONENT_PATTERNS = (
+	r"\bbasic\b",  # Basic, Basic Salary, Basic Pay, Basic Wages, Basic + DA
+	r"\bdearness\b",  # Dearness Allowance, Dearness Pay
+	r"\bda\b",  # DA, Basic + DA
+)
+
+_PF_WAGE_COMPONENT_RE = re.compile("|".join(PF_WAGE_COMPONENT_PATTERNS))
+
+
+def is_pf_wage_component(salary_component: str | None) -> bool:
+	"""True when a Salary Component name reads as Basic or Dearness Allowance.
+
+	Heuristic by design: there is no per-component PF flag, so a company that
+	names its basic component something unrecognisable (e.g. "Fixed Pay") will
+	not have it counted. ``apply_epf`` warns on the slip when EPF is applicable
+	but nothing matched, so that miss is visible rather than silent.
+	"""
+	if not salary_component:
+		return False
+	normalised = re.sub(r"[^a-z0-9]+", " ", salary_component.lower().replace(".", ""))
+	return bool(_PF_WAGE_COMPONENT_RE.search(normalised))
+
 
 def apply_epf(doc, method=None) -> None:
 	"""
@@ -38,6 +62,9 @@ def apply_epf(doc, method=None) -> None:
 	Employer contributions (EPF / EPS / EDLI / Admin) are configured as
 	"Employer Contribution" components on the Salary Structure and handled
 	by Salary Structure Assignment / CTC — not by this hook.
+
+	Contributions are computed on PF wage — the Basic and Dearness Allowance
+	earnings on the slip only (see ``_compute_pf_wage``) — never on gross pay.
 
 	Gated by a single `epf_applicable` flag on the Salary Structure Assignment.
 	All employees are assumed to be post-1 Sept 2014 EPF members.
@@ -73,7 +100,15 @@ def apply_epf(doc, method=None) -> None:
 
 	pf_wage = _compute_pf_wage(doc)
 	if pf_wage <= 0:
-		# Nothing to contribute on (e.g. no components flagged as PF wage)
+		frappe.msgprint(
+			frappe._(
+				"No Basic or Dearness Allowance earning was found on this Salary Slip, "
+				"so no EPF has been deducted. EPF applies only to Basic and Dearness "
+				"Allowance; rename the component accordingly if it is PF-eligible."
+			),
+			indicator="orange",
+			alert=True,
+		)
 		_remove_epf_components(doc)
 		return
 
@@ -107,34 +142,36 @@ def _required_components_exist() -> bool:
 
 
 def _compute_pf_wage(doc) -> float:
-	"""
-	Sum the PF-eligible earnings on the slip.
-
-	PF wage is *not* gross pay. Two categories of earning are excluded per
-	EPF statute (Sec. 2(b) excludes HRA; the EPFO circular excludes ad-hoc /
-	incentive-type pay):
-
-	  • HRA — identified from the Company master's ``hra_component`` field.
-	  • Any earning sourced from an Additional Salary (bonuses, incentives,
-	    arrears and other one-off components), flagged by ``additional_salary``
-	    on the slip row.
-
-	Amounts on `doc.earnings` are already prorated for LOP / payment_days by
-	the Salary Slip controller, so the returned PF wage reflects NCP days.
-	"""
-	hra_component = frappe.db.get_value("Company", doc.company, "hra_component") if doc.company else None
-
 	total = 0.0
 	for e in doc.earnings:
-		# Skip HRA — excluded from PF wage by statute.
-		if hra_component and e.salary_component == hra_component:
-			continue
-		# Skip anything injected from an Additional Salary (bonuses/incentives).
+		# Skip anything injected from an Additional Salary (bonuses/arrears).
 		if e.get("additional_salary"):
 			continue
-		total += flt(e.amount)
+		# Count only Basic / Dearness Allowance.
+		if not is_pf_wage_component(e.salary_component):
+			continue
+		total += flt(e.default_amount)
 
 	return total
+
+
+def _compute_monthly_epf_base(monthly_pf_wage: float, *, contribute_on_actual: bool) -> float:
+	annual_pf_wage = flt(monthly_pf_wage) * 12
+	annual_ceiling = EPF_WAGE_CEILING * 12
+	annual_base = annual_pf_wage if contribute_on_actual else min(annual_pf_wage, annual_ceiling)
+	return annual_base / 12
+
+
+def _lop_factor(doc) -> float:
+	"""Proration factor for LOP: paid days over total working days.
+
+	Falls back to 1.0 (no proration) when total working days is unavailable, so
+	the contribution is never divided by zero for a preview or a manual slip.
+	"""
+	total_days = flt(doc.total_working_days)
+	if total_days <= 0:
+		return 1.0
+	return flt(doc.payment_days) / total_days
 
 
 def _compute_vpf(doc, epf_base: float, *, vpf_mode=None, vpf_percentage=None, vpf_amount=None) -> float:

--- a/india_payroll/india_payroll/report/employee_provident_fund_register/employee_provident_fund_register.py
+++ b/india_payroll/india_payroll/report/employee_provident_fund_register/employee_provident_fund_register.py
@@ -15,6 +15,7 @@ from india_payroll.india_payroll.epf import (
 	EPS_RATE,
 	VPF_COMPONENT,
 	_epfo_round,
+	is_pf_wage_component,
 )
 from india_payroll.india_payroll.utils import get_effective_ssa_values
 
@@ -201,7 +202,7 @@ def get_data(filters):
 	if not slips:
 		return []
 
-	totals_by_slip = _aggregate_salary_detail({s.slip: s.company for s in slips})
+	totals_by_slip = _aggregate_salary_detail([s.slip for s in slips])
 
 	data = []
 	for s in slips:
@@ -252,30 +253,24 @@ def get_data(filters):
 	return data
 
 
-def _aggregate_salary_detail(company_by_slip: dict) -> dict:
+def _aggregate_salary_detail(slip_names: list[str]) -> dict:
 	"""One Salary Detail sweep across all slips in the report.
 
 	PF wage is the sum of PF-eligible earnings, mirroring ``epf._compute_pf_wage``:
-	HRA (identified from each slip's Company master ``hra_component``) and any
-	earning sourced from an Additional Salary (bonuses/incentives) are excluded.
+	only Basic and Dearness Allowance earnings count (matched by
+	``epf.is_pf_wage_component``), and anything sourced from an Additional
+	Salary (arrears/incentives) is excluded.
 
 	Returns: { slip_name: { "pf_wage": ..., "Provident Fund": ..., "Voluntary Provident Fund": ... } }
 	"""
-	if not company_by_slip:
+	if not slip_names:
 		return {}
-
-	# Cache hra_component per company so multi-company reports do one lookup each.
-	hra_by_company: dict[str, str | None] = {}
-	for company in set(company_by_slip.values()):
-		hra_by_company[company] = (
-			frappe.db.get_value("Company", company, "hra_component") if company else None
-		)
 
 	rows = frappe.get_all(
 		"Salary Detail",
 		filters={
 			"parenttype": "Salary Slip",
-			"parent": ("in", list(company_by_slip)),
+			"parent": ("in", slip_names),
 		},
 		fields=["parent", "parentfield", "salary_component", "amount", "additional_salary"],
 	)
@@ -284,11 +279,10 @@ def _aggregate_salary_detail(company_by_slip: dict) -> dict:
 	for r in rows:
 		bucket = totals.setdefault(r.parent, {})
 		if r.parentfield == "earnings":
-			hra_component = hra_by_company.get(company_by_slip.get(r.parent))
-			# Exclude HRA and Additional-Salary earnings from PF wage.
-			if hra_component and r.salary_component == hra_component:
-				continue
+			# Count only Basic / Dearness Allowance, and never Additional Salary.
 			if r.additional_salary:
+				continue
+			if not is_pf_wage_component(r.salary_component):
 				continue
 			bucket["pf_wage"] = flt(bucket.get("pf_wage")) + flt(r.amount)
 		elif r.parentfield == "deductions" and r.salary_component in (

--- a/india_payroll/india_payroll/test_epf.py
+++ b/india_payroll/india_payroll/test_epf.py
@@ -3,8 +3,11 @@
 
 import frappe
 from erpnext.setup.doctype.employee.test_employee import make_employee
-from frappe.utils import flt
-from hrms.payroll.doctype.salary_slip.test_salary_slip import make_salary_component
+from frappe.utils import add_days, flt, get_first_day
+from hrms.payroll.doctype.salary_slip.test_salary_slip import (
+	make_salary_component,
+	mark_attendance,
+)
 from hrms.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from hrms.payroll.doctype.salary_structure.test_salary_structure import (
 	create_salary_structure_assignment,
@@ -36,6 +39,20 @@ _EPF_TEST_EARNINGS = [
 	}
 ]
 
+# A Basic that depends on payment days: HRMS prorates its `amount` for LOP
+# while `default_amount` keeps the full monthly value.
+_EPF_LOP_COMPONENT = "EPF Test Basic LOP"
+_EPF_LOP_EARNINGS = [
+	{
+		"salary_component": _EPF_LOP_COMPONENT,
+		"abbr": "EPFTBL",
+		"formula": "base",
+		"type": "Earning",
+		"amount_based_on_formula": 1,
+		"depends_on_payment_days": 1,
+	}
+]
+
 _TEST_EMAILS = [
 	"test_epf_below_ceiling@indiapayroll.com",
 	"test_epf_all_earnings@indiapayroll.com",
@@ -48,6 +65,8 @@ _TEST_EMAILS = [
 	"test_epf_disabled_setting@indiapayroll.com",
 	"test_epf_net_pay@indiapayroll.com",
 	"test_epf_preview@indiapayroll.com",
+	"test_epf_lop_prorated@indiapayroll.com",
+	"test_epf_lop_register_match@indiapayroll.com",
 ]
 
 
@@ -123,6 +142,48 @@ class TestEPF(HRMSTestSuite):
 		)
 		salary_slip.start_date = start_date
 		salary_slip.end_date = end_date
+
+		return employee, salary_slip
+
+	def _make_lop_salary_slip(
+		self,
+		email: str,
+		structure_name: str,
+		base: float,
+		lop_days: tuple = (10, 11, 12),
+	):
+		"""Salary slip for June 2026 with a payment-days-dependent Basic and real LOP."""
+		if not frappe.db.exists("Salary Component", _EPF_LOP_COMPONENT):
+			make_salary_component(_EPF_LOP_EARNINGS, False, ["_Test Company"])
+
+		start = get_first_day("2026-06-01")
+		employee = make_employee(email, company="_Test Company", date_of_joining="2020-01-01")
+		frappe.db.set_value("Employee", employee, {"relieving_date": None, "status": "Active"})
+		frappe.db.delete("Attendance", {"employee": employee})
+
+		for day in lop_days:
+			mark_attendance(employee, add_days(start, day), "Absent", ignore_validate=True)
+
+		salary_structure = make_salary_structure(
+			structure_name,
+			"Monthly",
+			company="_Test Company",
+			currency="INR",
+			earnings=_EPF_LOP_EARNINGS,
+			deductions=[],
+		)
+		ssa = create_salary_structure_assignment(
+			employee,
+			salary_structure.name,
+			from_date="2026-06-01",
+			company="_Test Company",
+			base=base,
+		)
+		frappe.db.set_value("Salary Structure Assignment", ssa.name, "epf_applicable", 1)
+
+		salary_slip = make_salary_slip(salary_structure.name, employee=employee, posting_date="2026-06-30")
+		salary_slip.start_date = "2026-06-01"
+		salary_slip.end_date = "2026-06-30"
 
 		return employee, salary_slip
 
@@ -221,7 +282,13 @@ class TestEPF(HRMSTestSuite):
 
 	@HRMSTestSuite.change_settings(
 		"Payroll Settings",
-		{"enable_epf": 1, "enable_professional_tax": 0, "enable_esic": 0, "enable_lwf": 0},
+		{
+			"enable_epf": 1,
+			"enable_professional_tax": 0,
+			"enable_esic": 0,
+			"enable_lwf": 0,
+			"payroll_based_on": "Leave",
+		},
 	)
 	def test_vpf_amount_mode(self):
 		"""
@@ -265,6 +332,91 @@ class TestEPF(HRMSTestSuite):
 		# Fractional payment_days (half-day LOP) — 24.5/30 * 3000 = 2450.
 		half_day = frappe._dict(payment_days=24.5, total_working_days=30)
 		self.assertEqual(_compute_vpf(half_day, 15_000, **vpf_args), 2_450)
+
+	def test_pf_wage_uses_prorated_amount_not_default_amount(self):
+		"""
+		PF wage tracks the amount actually paid. For a component that depends on
+		payment days HRMS prorates ``amount`` for LOP while ``default_amount``
+		keeps the full monthly value; EPF must follow ``amount``, which is what
+		the EPF register and the ECR report as EPF wages.
+		"""
+		from india_payroll.india_payroll.epf import _compute_pf_wage
+
+		doc = frappe._dict(
+			company="_Test Company",
+			earnings=[
+				# Half a month of LOP: structure wage 20,000, paid 10,000.
+				frappe._dict(salary_component="Basic Salary", default_amount=20_000, amount=10_000),
+				frappe._dict(salary_component="Dearness Allowance", default_amount=4_000, amount=2_000),
+			],
+		)
+
+		self.assertEqual(_compute_pf_wage(doc), 12_000)
+
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings",
+		{
+			"enable_epf": 1,
+			"enable_professional_tax": 0,
+			"enable_esic": 0,
+			"enable_lwf": 0,
+			"payroll_based_on": "Attendance",
+		},
+	)
+	def test_epf_on_lop_matches_epf_register(self):
+		"""
+		A payment-days-dependent Basic above the ceiling, with LOP: the EPF
+		deducted on the slip must equal 12% of the EPF wages the register
+		reports, so the slip and the ECR cannot disagree.
+		"""
+		from india_payroll.india_payroll.report.employee_provident_fund_register.employee_provident_fund_register import (
+			execute,
+		)
+
+		employee, slip = self._make_lop_salary_slip(
+			"test_epf_lop_register_match@indiapayroll.com",
+			"Test EPF LOP Register Structure",
+			30_000.0,
+		)
+		slip.insert()
+		slip.submit()
+
+		# LOP actually took effect, so `amount` is below `default_amount`.
+		earning = slip.earnings[0]
+		self.assertLess(flt(earning.amount), flt(earning.default_amount))
+
+		rows = execute(frappe._dict({"company": "_Test Company", "from_year": 2026, "month": "June"}))[1]
+		row = next(r for r in rows if r["employee"] == employee)
+
+		slip_epf = self._amount(slip, "deductions", EPF_EMPLOYEE_COMPONENT)
+		self.assertEqual(row["epf_wages"], flt(earning.amount))
+		self.assertEqual(slip_epf, row["employee_epf"])
+		self.assertEqual(slip_epf, round(flt(row["epf_wages"]) * 0.12))
+
+	@HRMSTestSuite.change_settings(
+		"Payroll Settings",
+		{
+			"enable_epf": 1,
+			"enable_professional_tax": 0,
+			"enable_esic": 0,
+			"enable_lwf": 0,
+			"payroll_based_on": "Attendance",
+		},
+	)
+	def test_percentage_vpf_follows_prorated_pf_wage(self):
+		"""Percentage VPF is a share of the EPF base, so it prorates with LOP too."""
+		employee, slip = self._make_lop_salary_slip(
+			"test_epf_lop_prorated@indiapayroll.com",
+			"Test EPF LOP VPF Structure",
+			10_000.0,
+		)
+		self._set_ssa(employee, {"vpf_mode": "Percentage", "vpf_percentage": 5})
+		slip.insert()
+
+		paid_wage = flt(slip.earnings[0].amount)
+		self.assertLess(paid_wage, 10_000)
+		self.assertEqual(self._amount(slip, "deductions", EPF_EMPLOYEE_COMPONENT), round(paid_wage * 0.12))
+		self.assertEqual(self._amount(slip, "deductions", VPF_COMPONENT), round(paid_wage * 0.05))
 
 	def test_pf_wage_counts_only_basic_and_dearness_allowance(self):
 		"""

--- a/india_payroll/india_payroll/test_epf.py
+++ b/india_payroll/india_payroll/test_epf.py
@@ -361,6 +361,7 @@ class TestEPF(HRMSTestSuite):
 			"enable_esic": 0,
 			"enable_lwf": 0,
 			"payroll_based_on": "Attendance",
+			"consider_unmarked_attendance_as": "Present",
 		},
 	)
 	def test_epf_on_lop_matches_epf_register(self):
@@ -369,29 +370,33 @@ class TestEPF(HRMSTestSuite):
 		deducted on the slip must equal 12% of the EPF wages the register
 		reports, so the slip and the ECR cannot disagree.
 		"""
+		from india_payroll.india_payroll.epf import EPF_EMPLOYEE_RATE, _epfo_round
 		from india_payroll.india_payroll.report.employee_provident_fund_register.employee_provident_fund_register import (
 			execute,
 		)
 
+		# Structure wage sits above the ceiling but the LOP-prorated wage falls
+		# below it: capping the full wage instead of the paid wage over-deducts.
 		employee, slip = self._make_lop_salary_slip(
 			"test_epf_lop_register_match@indiapayroll.com",
 			"Test EPF LOP Register Structure",
-			30_000.0,
+			16_000.0,
 		)
 		slip.insert()
 		slip.submit()
 
-		# LOP actually took effect, so `amount` is below `default_amount`.
 		earning = slip.earnings[0]
-		self.assertLess(flt(earning.amount), flt(earning.default_amount))
+		paid_wage = flt(earning.amount)
+		self.assertLess(paid_wage, flt(earning.default_amount), "LOP did not reduce the paid wage")
+		self.assertLess(paid_wage, EPF_WAGE_CEILING, "paid wage must fall below the ceiling")
 
 		rows = execute(frappe._dict({"company": "_Test Company", "from_year": 2026, "month": "June"}))[1]
 		row = next(r for r in rows if r["employee"] == employee)
 
 		slip_epf = self._amount(slip, "deductions", EPF_EMPLOYEE_COMPONENT)
-		self.assertEqual(row["epf_wages"], flt(earning.amount))
+		self.assertEqual(row["epf_wages"], min(paid_wage, EPF_WAGE_CEILING))
 		self.assertEqual(slip_epf, row["employee_epf"])
-		self.assertEqual(slip_epf, round(flt(row["epf_wages"]) * 0.12))
+		self.assertEqual(slip_epf, _epfo_round(flt(row["epf_wages"]) * EPF_EMPLOYEE_RATE))
 
 	@HRMSTestSuite.change_settings(
 		"Payroll Settings",
@@ -401,6 +406,7 @@ class TestEPF(HRMSTestSuite):
 			"enable_esic": 0,
 			"enable_lwf": 0,
 			"payroll_based_on": "Attendance",
+			"consider_unmarked_attendance_as": "Present",
 		},
 	)
 	def test_percentage_vpf_follows_prorated_pf_wage(self):
@@ -413,10 +419,15 @@ class TestEPF(HRMSTestSuite):
 		self._set_ssa(employee, {"vpf_mode": "Percentage", "vpf_percentage": 5})
 		slip.insert()
 
+		from india_payroll.india_payroll.epf import EPF_EMPLOYEE_RATE, _epfo_round
+
 		paid_wage = flt(slip.earnings[0].amount)
-		self.assertLess(paid_wage, 10_000)
-		self.assertEqual(self._amount(slip, "deductions", EPF_EMPLOYEE_COMPONENT), round(paid_wage * 0.12))
-		self.assertEqual(self._amount(slip, "deductions", VPF_COMPONENT), round(paid_wage * 0.05))
+		self.assertLess(paid_wage, 10_000, "LOP did not reduce the paid wage")
+		self.assertEqual(
+			self._amount(slip, "deductions", EPF_EMPLOYEE_COMPONENT),
+			_epfo_round(paid_wage * EPF_EMPLOYEE_RATE),
+		)
+		self.assertEqual(self._amount(slip, "deductions", VPF_COMPONENT), _epfo_round(paid_wage * 0.05))
 
 	def test_pf_wage_counts_only_basic_and_dearness_allowance(self):
 		"""

--- a/india_payroll/india_payroll/test_epf.py
+++ b/india_payroll/india_payroll/test_epf.py
@@ -20,9 +20,10 @@ from india_payroll.india_payroll.epf import (
 from india_payroll.install import create_epf_components
 
 # The earning component used as Basic across all EPF tests. Basic is
-# PF-eligible; formula `base` keeps gross_pay equal to the SSA base for
-# predictable assertions. HRA and Additional-Salary earnings are excluded from
-# PF wage (see test_pf_wage_excludes_hra_and_additional_salary).
+# PF-eligible (its name matches the Basic/DA heuristic); formula `base` keeps
+# gross_pay equal to the SSA base for predictable assertions. Only Basic and
+# Dearness Allowance count towards PF wage — see
+# test_pf_wage_counts_only_basic_and_dearness_allowance.
 _EPF_BASIC_COMPONENT = "EPF Test Basic"
 _EPF_TEST_EARNINGS = [
 	{
@@ -265,29 +266,81 @@ class TestEPF(HRMSTestSuite):
 		half_day = frappe._dict(payment_days=24.5, total_working_days=30)
 		self.assertEqual(_compute_vpf(half_day, 15_000, **vpf_args), 2_450)
 
-	def test_pf_wage_excludes_hra_and_additional_salary(self):
+	def test_pf_wage_counts_only_basic_and_dearness_allowance(self):
 		"""
-		PF wage must count only PF-eligible earnings. HRA (identified from the
-		Company master's ``hra_component``) and any earning sourced from an
-		Additional Salary (bonuses/incentives, flagged by ``additional_salary``)
-		are excluded — only Basic remains.
+		PF wage is an inclusion list: only Basic and Dearness Allowance attract
+		EPF. Every other earning — HRA, conveyance, special allowance — is
+		ignored, as is anything sourced from an Additional Salary even when the
+		component itself reads as Basic/DA.
 		"""
 		from india_payroll.india_payroll.epf import _compute_pf_wage
-
-		# Point the Company at an HRA component so the lookup resolves.
-		frappe.db.set_value("Company", "_Test Company", "hra_component", "HRA")
 
 		doc = frappe._dict(
 			company="_Test Company",
 			earnings=[
-				frappe._dict(salary_component="Basic Salary", amount=20_000),
-				frappe._dict(salary_component="HRA", amount=8_000),
-				frappe._dict(salary_component="Bonus", amount=5_000, additional_salary="ADSAL-0001"),
+				frappe._dict(salary_component="Basic Salary", default_amount=20_000, amount=20_000),
+				frappe._dict(salary_component="Dearness Allowance", default_amount=4_000, amount=4_000),
+				frappe._dict(salary_component="HRA", default_amount=8_000, amount=8_000),
+				frappe._dict(salary_component="Conveyance Allowance", default_amount=1_600, amount=1_600),
+				frappe._dict(salary_component="Special Allowance", default_amount=9_000, amount=9_000),
+				frappe._dict(
+					salary_component="Basic Arrear",
+					default_amount=5_000,
+					amount=5_000,
+					additional_salary="ADSAL-0001",
+				),
 			],
 		)
 
-		# Only Basic counts → 20,000 (HRA and the Additional-Salary bonus dropped).
-		self.assertEqual(_compute_pf_wage(doc), 20_000)
+		# Basic 20,000 + DA 4,000. Everything else drops out.
+		self.assertEqual(_compute_pf_wage(doc), 24_000)
+
+	def test_is_pf_wage_component_heuristic(self):
+		"""The name heuristic recognises Basic/DA spellings and nothing else."""
+		from india_payroll.india_payroll.epf import is_pf_wage_component
+
+		for name in (
+			"Basic",
+			"Basic Salary",
+			"Basic Pay",
+			"BASIC WAGES",
+			"Basic + DA",
+			"Basic + D.A.",
+			"Dearness Allowance",
+			"Dearness Allowance (DA)",
+			"DA",
+			"EPF Test Basic",
+		):
+			self.assertTrue(is_pf_wage_component(name), f"{name!r} should be PF wage")
+
+		for name in (
+			"House Rent Allowance",
+			"HRA",
+			"Conveyance Allowance",
+			"Special Allowance",
+			"Medical Allowance",
+			"Performance Bonus",
+			"Leave Encashment",
+			"Daily Allowance",
+			"Arrear",
+			"",
+			None,
+		):
+			self.assertFalse(is_pf_wage_component(name), f"{name!r} should not be PF wage")
+
+	def test_pf_wage_zero_when_no_basic_component(self):
+		"""A structure with no recognisable Basic/DA earning yields no PF wage."""
+		from india_payroll.india_payroll.epf import _compute_pf_wage
+
+		doc = frappe._dict(
+			company="_Test Company",
+			earnings=[
+				frappe._dict(salary_component="Fixed Pay", default_amount=50_000, amount=50_000),
+				frappe._dict(salary_component="HRA", default_amount=20_000, amount=20_000),
+			],
+		)
+
+		self.assertEqual(_compute_pf_wage(doc), 0)
 
 	@HRMSTestSuite.change_settings(
 		"Payroll Settings",


### PR DESCRIPTION
## Problem

PF wage was computed as *every* earning on the slip minus a couple of
exclusions — HRA (via `Company.hra_component`) and anything sourced from an
Additional Salary. That over-counts: any allowance a company adds (special,
conveyance, medical, transport…) silently entered the PF base and inflated
the employee's EPF deduction.

Per the EPF & MP Act 1952 (Sec. 2(b), Sec. 6), PF wage is **basic wages plus
dearness allowance** — not gross pay less a blocklist.

## Change

Flips PF wage from an exclusion list to an **inclusion list**: only Basic and
Dearness Allowance earnings count.

Salary Component names are free text and there is no per-component
(`include_in_pf_wage` was dropped in `v1_0/remove_include_in_pf_wage_field`),
so the two eligible components are identified by a name heuristic
`epf.is_pf_wage_component()`. The name is lowercased, `.` removed, and any
other non-alphanumeric run collapsed to a single space before matc
`PF_WAGE_COMPONENT_PATTERNS`:

| Pattern         | Matches                                                      |
|-----------------|-----------------------------------------------
| `\bbasic\b`     | Basic, Basic Salary, Basic Pay, BASIC WAGES, Basic + DA        |
| `\bdearness\b`  | Dearness Allowance, Dearness Pay
| `\bda\b`        | DA, Basic + D.A., Dearness Allowance (DA)                      |

Non-matches include House Rent Allowance, Conveyance / Special / Medical
Allowance, Performance Bonus, Leave Encashment — and near-misses s
"Daily Allowance" and "Data Allowance", which `\bda\b` does not catch.

Notable details:

- **Additional Salary earnings stay excluded**, even when the component reads
  as Basic/DA (e.g. "Basic Arrear"). Arrears and incentives are ad
  not the running structure wage the ceiling test is decided on. Unchanged
  behaviour.
- **The HRA lookup is gone.** It is redundant under an inclusion list, and
  dropping it removes a `Company.hra_component` DB read per slip.
- **Silent-zero guard.** A heuristic can miss — a company whose basic
  component is named "Fixed Pay" would get no EPF at all. `apply_e
  raises an orange alert on the slip when EPF is opted into on the assignment
  but no Basic/DA earning matched, instead of quietly deducting no
- **Employee Provident Fund Register mirrors the same rule** through the
  shared `is_pf_wage_component`, so the register and the slip cann
  `_aggregate_salary_detail` no longer needs the company→slip map and now
  takes a plain list of slip names.

## Impact

This lowers EPF for any employee whose structure has PF-ineligible
Example (demo data): Basic ₹10,000 + HRA ₹4,000 + Special Allowance ₹6,000 —
PF wage drops from ₹20,000 to ₹10,000.