### PR TITLE
fix: Restore PF wage aggregation in EPF register

### DIFF
--- a/india_payroll/india_payroll/report/employee_provident_fund_register/employee_provident_fund_register.py
+++ b/india_payroll/india_payroll/report/employee_provident_fund_register/employee_provident_fund_register.py
@@ -292,21 +292,14 @@ def _aggregate_salary_detail(slip_names: list[str]) -> dict:
 
 	Returns: { slip_name: { "pf_wage": ..., "Provident Fund": ..., "Voluntary Provident Fund": ... } }
 	"""
-	if not company_by_slip:
+	if not slip_names:
 		return {}
-
-	# Cache hra_component per company so multi-company reports do one lookup each.
-	hra_by_company: dict[str, str | None] = {}
-	for company in set(company_by_slip.values()):
-		hra_by_company[company] = (
-			frappe.db.get_value("Company", company, "hra_component") if company else None
-		)
 
 	rows = frappe.get_all(
 		"Salary Detail",
 		filters={
 			"parenttype": "Salary Slip",
-			"parent": ("in", list(company_by_slip)),
+			"parent": ("in", slip_names),
 		},
 		fields=["parent", "parentfield", "salary_component", "amount", "additional_salary"],
 	)


### PR DESCRIPTION
The version-16-hotfix merge into develop left _aggregate_salary_detail in a half-merged state. The hotfix reworked it to take a company_by_slip map so HRA could be excluded per company, while develop had reworked the same function to count only Basic and Dearness Allowance via is_pf_wage_component. The merge kept develop's signature, caller and loop body but the hotfix's guard and HRA lookup, leaving three references to an undefined company_by_slip.

That is a NameError on every call, so the Provident Fund Register and the ECR export both raised, failing the Server job. Ruff caught the same thing as F821, failing the Frappe Linter job.

Resolved in favour of develop: epf.py at the merge commit computes PF wage from Basic and Dearness Allowance only, so the register must mirror that to stay consistent with the deduction it reports. The Basic/DA rule already excludes HRA, so the hotfix's intent is preserved. Dropped the orphaned company_by_slip guard and the now-unused hra_by_company lookup.