### PR TITLE
fix: update maharashtra women's professional tax exemption to 25000

### DIFF
--- a/india_payroll/india_payroll/professional_tax.py
+++ b/india_payroll/india_payroll/professional_tax.py
@@ -86,7 +86,7 @@ STATE_PT_CONFIG = {
 		"frequency": "monthly",
 		# Slabs represent normal (non-February) amounts.
 		# For salaries > ₹10,000 the February rule applies (see special_rules).
-		# Women earning ≤ ₹10,000/month are fully exempt.
+		# From 1 April 2023, women earning ≤ ₹25,000/month are fully exempt.
 		"slabs": [
 			{"upto": 7500, "amount": 0},
 			{"upto": 10000, "amount": 175},
@@ -98,7 +98,7 @@ STATE_PT_CONFIG = {
 			# 11 months * ₹200 + February * ₹300 = ₹2,500
 			"february_amount": 300,
 			# Women earning up to this monthly gross are fully exempt
-			"women_exemption_upto": 10000,
+			"women_exemption_upto": 25000,
 		},
 	},
 	"Meghalaya": {
@@ -264,7 +264,7 @@ def _compute_pt_monthly(gross_pay: float, state_config: dict, month: int, gender
 	Return the Professional Tax amount for a monthly-frequency state.
 
 	Handles:
-	  • Maharashtra women exemption (≤ ₹10,000 gross → exempt)
+	  • Maharashtra women exemption (≤ ₹25,000 gross → exempt)
 	  • Maharashtra February rule (₹300 instead of ₹200 for highest slab)
 	"""
 	special_rules = state_config.get("special_rules", {})

--- a/india_payroll/india_payroll/test_professional_tax.py
+++ b/india_payroll/india_payroll/test_professional_tax.py
@@ -10,12 +10,40 @@ from hrms.payroll.doctype.salary_structure.test_salary_structure import (
 )
 from hrms.tests.utils import HRMSTestSuite
 
+from india_payroll.india_payroll.professional_tax import STATE_PT_CONFIG, _compute_pt_monthly
 from india_payroll.install import create_professional_tax_component
 
 
 class TestProfessionalTax(HRMSTestSuite):
 	def setUp(self):
 		create_professional_tax_component()
+
+	def test_maharashtra_women_exempt_up_to_25000_including_february(self):
+		for month in range(1, 13):
+			for gross_pay in (0, 10000, 10001, 20000, 25000):
+				with self.subTest(month=month, gross_pay=gross_pay):
+					self.assertEqual(
+						_compute_pt_monthly(gross_pay, STATE_PT_CONFIG["Maharashtra"], month, "Female"),
+						0,
+					)
+
+	def test_maharashtra_women_above_exemption_pay_monthly_and_february_rates(self):
+		for month in range(1, 13):
+			for gross_pay in (25000.01, 25001, 50000):
+				with self.subTest(month=month, gross_pay=gross_pay):
+					self.assertEqual(
+						_compute_pt_monthly(gross_pay, STATE_PT_CONFIG["Maharashtra"], month, "Female"),
+						300 if month == 2 else 200,
+					)
+
+	def test_maharashtra_men_keep_existing_slab_rates(self):
+		for month in range(1, 13):
+			for gross_pay, expected in ((7500, 0), (7501, 175), (10000, 175), (10001, 200), (25000, 200)):
+				with self.subTest(month=month, gross_pay=gross_pay):
+					self.assertEqual(
+						_compute_pt_monthly(gross_pay, STATE_PT_CONFIG["Maharashtra"], month, "Male"),
+						300 if month == 2 and gross_pay > 10000 else expected,
+					)
 
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_professional_tax": 1})
 	def test_maharashtra_professional_tax_applied_on_salary_slip(self):
@@ -61,9 +89,9 @@ class TestProfessionalTax(HRMSTestSuite):
 	@HRMSTestSuite.change_settings("Payroll Settings", {"enable_professional_tax": 1})
 	def test_maharashtra_february_amount_for_female_employee(self):
 		"""
-		A female employee in Maharashtra with gross pay > ₹10,000 should have
+		A female employee in Maharashtra with gross pay > ₹25,000 should have
 		₹300 Professional Tax deducted in February (women exemption does not apply
-		above ₹10,000; February special amount applies instead of the usual ₹200).
+		above ₹25,000; February special amount applies instead of the usual ₹200).
 		"""
 		employee = make_employee(
 			"test_maharashtra_pt_female_feb@indiapayroll.com",


### PR DESCRIPTION
**Description:** Professional tax being deducted from women in Maharashtra earning between ₹10,000 and ₹25,000 per month by raising the exemption threshold to ₹25,000